### PR TITLE
Multiple evaluation

### DIFF
--- a/Lisp-Dep/mp-nil.lisp
+++ b/Lisp-Dep/mp-nil.lisp
@@ -19,8 +19,8 @@
 ;;; Library General Public License for more details.
 ;;;
 ;;; You should have received a copy of the GNU Library General Public
-;;; License along with this library; if not, write to the 
-;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330, 
+;;; License along with this library; if not, write to the
+;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 ;;; Boston, MA  02111-1307  USA.
 
 (in-package :clim-internals)
@@ -124,16 +124,16 @@
 (defun condition-wait (cv lock &optional timeout)
   (declare (ignore lock))
   (flet ((wait-func ()
-	   (loop for port in climi::*all-ports*	;; this is dubious
+           (loop for port in climi::*all-ports*	;; this is dubious
                  do (loop as this-event = (process-next-event port :timeout 0)
                      for got-events = this-event then (or got-events this-event)
                      while this-event
                      finally (unless got-events (process-next-event port))))
-	   (car cv)))
+           (car cv)))
     (setf (car cv) nil)
     (if timeout
-	(process-wait-with-timeout "Waiting for event" timeout #'wait-func)
-	(process-wait "Waiting for event" #'wait-func))))
+        (process-wait-with-timeout "Waiting for event" timeout #'wait-func)
+        (process-wait "Waiting for event" #'wait-func))))
 
 (defun condition-notify (cv)
   (setf (car cv) t))

--- a/Lisp-Dep/mp-sbcl.lisp
+++ b/Lisp-Dep/mp-sbcl.lisp
@@ -22,8 +22,8 @@
 ;;; Library General Public License for more details.
 ;;;
 ;;; You should have received a copy of the GNU Library General Public
-;;; License along with this library; if not, write to the 
-;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330, 
+;;; License along with this library; if not, write to the
+;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 ;;; Boston, MA  02111-1307  USA.
 
 (in-package :CLIM-INTERNALS)
@@ -34,8 +34,8 @@
   (pushnew :clim-mp *features*))
 
 (defstruct (process
-	     (:constructor %make-process)
-	     (:predicate processp))
+             (:constructor %make-process)
+             (:predicate processp))
   name
   state
   whostate
@@ -57,7 +57,7 @@ running when this file was loaded.")
 (defun reinit-processes ()
   (setf *current-process* (make-current-process))
   (setf *all-processes* (list *current-process*)))
- 
+
 (push 'reinit-processes sb-ext:*init-hooks*)
 
 (defvar *all-processes-lock*
@@ -78,10 +78,10 @@ running when this file was loaded.")
 
 (defun restart-process (p)
   (labels ((boing ()
-	     (let ((*current-process* p))
+             (let ((*current-process* p))
                (sb-thread:with-mutex (*all-processes-lock*)
                  (pushnew p *all-processes*))
-	       (unwind-protect (funcall (process-function p))
+               (unwind-protect (funcall (process-function p))
                  (sb-thread:with-mutex (*all-processes-lock*)
                    (setf *all-processes* (delete p *all-processes*)))))))
     (when (process-thread p) (sb-thread:terminate-thread p))
@@ -96,7 +96,7 @@ running when this file was loaded.")
       *current-process*
       (setf *current-process*
             (or (find sb-thread:*current-thread* *all-processes*
-                 :key #'process-thread)
+                      :key #'process-thread)
                 ;; Don't add this to *all-processes*, because we don't
                 ;; control it.
                 (%make-process
@@ -122,29 +122,29 @@ running when this file was loaded.")
 (defun process-wait (reason predicate)
   (let ((old-state (process-whostate *current-process*)))
     (unwind-protect
-	 (progn
-	   (setf old-state (process-whostate *current-process*)
-		 (process-whostate *current-process*) reason)
-	   (loop 
-	    (let ((it (funcall predicate)))
-	      (when it (return it)))
-	    ;(sleep .01)
-               (yield)))
+         (progn
+           (setf old-state (process-whostate *current-process*)
+                 (process-whostate *current-process*) reason)
+           (loop
+              (let ((it (funcall predicate)))
+                (when it (return it)))
+                                        ;(sleep .01)
+              (yield)))
       (setf (process-whostate *current-process*) old-state))))
 
 (defun process-wait-with-timeout (reason timeout predicate)
   (let ((old-state (process-whostate *current-process*))
-	(end-time (+ (get-universal-time) timeout)))
+        (end-time (+ (get-universal-time) timeout)))
     (unwind-protect
-	 (progn
-	   (setf old-state (process-whostate *current-process*)
-		 (process-whostate *current-process*) reason)
-	   (loop 
-	    (let ((it (funcall predicate)))
-	      (when (or (> (get-universal-time) end-time) it)
-		(return it)))
-	    ;(sleep .01)))
-               (yield)))
+         (progn
+           (setf old-state (process-whostate *current-process*)
+                 (process-whostate *current-process*) reason)
+           (loop
+              (let ((it (funcall predicate)))
+                (when (or (> (get-universal-time) end-time) it)
+                  (return it)))
+                                        ;(sleep .01)))
+              (yield)))
       (setf (process-whostate *current-process*) old-state))))
 
 (defun process-interrupt (process function)
@@ -173,11 +173,11 @@ running when this file was loaded.")
 
 (defmacro atomic-incf (place)
   `(sb-thread:with-mutex (*atomic-lock*)
-    (incf ,place)))
+     (incf ,place)))
 
-(defmacro atomic-decf (place) 
+(defmacro atomic-decf (place)
   `(sb-thread:with-mutex (*atomic-lock*)
-    (decf ,place)))
+     (decf ,place)))
 
 ;;; 32.3 Locks
 
@@ -187,15 +187,15 @@ running when this file was loaded.")
 (defmacro with-lock-held ((place &optional state) &body body)
   (let ((old-state (gensym "OLD-STATE")))
     `(let (,old-state)
-      (unwind-protect
-           (progn
-             (sb-thread:get-mutex ,place)
-	     (when ,state
-	       (setf ,old-state (process-state *current-process*))
-	       (setf (process-state *current-process*) ,state))
-             ,@body)
-        (setf (process-state *current-process*) ,old-state)
-        (sb-thread::release-mutex ,place)))))
+       (unwind-protect
+            (progn
+              (sb-thread:get-mutex ,place)
+              (when ,state
+                (setf ,old-state (process-state *current-process*))
+                (setf (process-state *current-process*) ,state))
+              ,@body)
+         (setf (process-state *current-process*) ,old-state)
+         (sb-thread::release-mutex ,place)))))
 
 
 (defun make-recursive-lock (&optional name)
@@ -203,27 +203,27 @@ running when this file was loaded.")
 
 (defmacro with-recursive-lock-held ((place &optional state) &body body)
   (let ((old-state (gensym "OLD-STATE")))
-  `(sb-thread:with-recursive-lock (,place)
-    (let (,old-state)
-      (unwind-protect
-	   (progn
-	     (when ,state
-	       (setf ,old-state (process-state *current-process*))
-	       (setf (process-state *current-process*) ,state))
-	     ,@body)
-	(setf (process-state *current-process*) ,old-state))))))
+    `(sb-thread:with-recursive-lock (,place)
+       (let (,old-state)
+         (unwind-protect
+              (progn
+                (when ,state
+                  (setf ,old-state (process-state *current-process*))
+                  (setf (process-state *current-process*) ,state))
+                ,@body)
+           (setf (process-state *current-process*) ,old-state))))))
 
 (defun make-condition-variable () (sb-thread:make-waitqueue))
 
 (defun condition-wait (cv lock &optional timeout)
   (if timeout
-      (handler-case 
-	  (sb-ext:with-timeout timeout
-	    (sb-thread:condition-wait cv lock)
-	    t)
-	(sb-ext:timeout (c)
-	  (declare (ignore c))
-	  nil))
+      (handler-case
+          (sb-ext:with-timeout timeout
+            (sb-thread:condition-wait cv lock)
+            t)
+        (sb-ext:timeout (c)
+          (declare (ignore c))
+          nil))
       (progn (sb-thread:condition-wait cv lock) t)))
 
 (defun condition-notify (cv)


### PR DESCRIPTION
This commit fixes a small macro bug where with-lock-held and with-recursive-lock-held would evaluate the state form more than once.

This change is based on a re-indent and whitespace fixup, which I really only did to get a clean patch. Feel free to cherry-pick the tip commit.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/robert-strandh/mcclim/4)
<!-- Reviewable:end -->
