### PR TITLE
Don't depend on swank, minor CLX fix

### DIFF
--- a/Backends/CLX/medium.lisp
+++ b/Backends/CLX/medium.lisp
@@ -1092,7 +1092,8 @@ time an indexed pattern is drawn.")
           (multiple-value-bind (halt width)
               (xlib:draw-glyphs mirror gc x y string
                                 :start start :end end
-                                :translate #'translate)
+                                :translate #'translate
+                                :size 16)
 	    (declare (ignore halt width))))))))
 
 (defmethod medium-buffering-output-p ((medium clx-medium))

--- a/mcclim.asd
+++ b/mcclim.asd
@@ -34,20 +34,30 @@
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defun find-swank-package ()
-    (find-package :swank))
+    #-clim-without-swank (find-package :swank)
+    #+clim-without-swank nil)
   (defun find-swank-system ()
+    #+clim-without-swank nil
+    #-clim-without-swank
     (handler-case (asdf:find-system :swank)
       (asdf:missing-component ())))
   (defun find-swank ()
+    #+clim-without-swank nil
+    #-clim-without-swank
     (or (find-swank-package)
         (find-swank-system)))
   (defun dep-on-swank ()
-    (if (and (find-swank-system)
-             (not (find-package :swank)))
+    (if (and 
+          #+clim-without-swank nil
+          (find-swank-system)
+          (not (find-package :swank)))
         '(:and)
         '(:or)))
   (defun ifswank ()
-    (if (find-swank)
+    
+    (if (and
+          #+clim-without-swank nil
+          (find-swank))
         '(:and)
         '(:or))))
 


### PR DESCRIPTION
The mcclim.asd file can now be loaded in a mode, which makes it not depend on swank in any form. To use this, push ":clim-without-swank" onto "*features*" prior to asdf:load-op'ing (or ql:quickload'ing) the system.

The CLX backend now passes the ":size 16" parameter do xlib:draw-glyphs in medium-draw-text*. This was done since forever already be medium-draw-glyph, but it seems to have been missing from draw-text*. I think, that this fix is more important than the swank issue, and I can create a separate pull-request, if you don't want to have both topics intermixed.