### PR TITLE
The color table is now weak on the values

### DIFF
--- a/design.lisp
+++ b/design.lisp
@@ -120,7 +120,10 @@
     `(make-named-color ',name ,red ,green ,blue)))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (defvar *color-hash-table* (make-hash-table :test #'eql)))
+  (defvar *color-hash-table* 
+    #+sbcl (make-hash-table :test #'eql :weakness :value) ; maybe, this should go into
+    #+ccl (make-hash-table :test #'eql :weak :value)      ; CLIM-SYS?
+    #-(or sbcl ccl) (make-hash-table :test #'eql)))
 
 (defun compute-color-key (red green blue)
   (+ (ash (round (* 255 red)) 16)


### PR DESCRIPTION
The hash table used to cache color objects uses weak references for the values on implementations, which support this (and where I know how to implement it), currently CCL and SBCL.