### PR TITLE
sheet-mirror ((pixmap mirrored-pixmap))

### DIFF
--- a/Examples/gadget-test.lisp
+++ b/Examples/gadget-test.lisp
@@ -137,6 +137,7 @@
                  :current-color +black+)
      (slider-v   :slider
                  :min-value 0
+		 :show-value-p t
                  :max-value 100
                  :orientation :vertical
                  :current-color +black+
@@ -156,6 +157,7 @@
      (slider-v3  :slider
                  :min-value 0
                  :max-value 100
+		 :show-value-p t
                  :orientation :vertical
                  :current-color +black+
                  :value 0)

--- a/gadgets.lisp
+++ b/gadgets.lisp
@@ -1693,9 +1693,9 @@ and must never be nil."))
 
 (defmethod handle-event ((pane slider-pane) (event pointer-exit-event))
   (with-slots (armed) pane
-    (when armed
-      (setf armed nil))
-    (disarmed-callback pane (gadget-client pane) (gadget-id pane))))
+    (when (and armed (not (eq armed ':button-press)))
+      (setf armed nil)
+      (disarmed-callback pane (gadget-client pane) (gadget-id pane)))))
 
 (defmethod handle-event ((pane slider-pane) (event pointer-button-press-event))
   (with-slots (armed) pane
@@ -1790,8 +1790,10 @@ and must never be nil."))
                (when (gadget-show-value-p pane)
                  (draw-text* pane (format-value (gadget-value pane)
                                                 (slider-decimal-places pane))
-                             5 ;(- position slider-button-half-short-dim)
-                             (- middle slider-button-half-long-dim)))))
+                             ;; without knowing the text size
+			     ;; there is only one safe position where we can put it
+                             (+ middle 10.0)
+			     (- y2 (* 2 slider-button-half-short-dim))))))
             ((:horizontal)
              (let ((middle (round (- y2 y1) 2)))
                (draw-bordered-polygon pane
@@ -1805,8 +1807,8 @@ and must never be nil."))
               (when (gadget-show-value-p pane)
 	        (draw-text* pane (format-value (gadget-value pane)
                                                (slider-decimal-places pane))
-			         5 ;(- position slider-button-half-short-dim)
-			         (- middle slider-button-half-long-dim)))))))))))
+			         (+ x1 (* 2 slider-button-half-short-dim))
+			         (- middle 10.0)))))))))))
 
 #|
 (defmethod handle-repaint ((pane slider-pane) region)

--- a/pixmap.lisp
+++ b/pixmap.lisp
@@ -92,3 +92,6 @@
 
 (defmethod sheet-direct-mirror ((pixmap mirrored-pixmap))
   (port-lookup-mirror (port pixmap) pixmap))
+
+(defmethod sheet-mirror ((pixmap mirrored-pixmap))
+  (port-lookup-mirror (port pixmap) pixmap))


### PR DESCRIPTION
A. Fix simple-error:
  Backtrace:
    0: ((:METHOD NO-APPLICABLE-METHOD (T)) #<STANDARD-GENERIC-FUNCTION CLIM:SHEET-MIRROR (3)> #<CLIM-INTERNALS::MIRRORED-PIXMAP {10111572F3}>) [fast-method]
    1: (SB-PCL::CALL-NO-APPLICABLE-METHOD #<STANDARD-GENERIC-FUNCTION CLIM:SHEET-MIRROR (3)> (#<CLIM-INTERNALS::MIRRORED-PIXMAP {10111572F3}>))
    2: ((:METHOD CLIM:MEDIUM-DRAW-POINT* (CLIM-CLX::CLX-MEDIUM T T)) #<CLIM-CLX::CLX-MEDIUM {1011157573}> 0 0) [fast-method]
 
------
B. Improve activate/deactivate widgets