### PR TITLE
atomic-incf/decf & ttf paths

### DIFF
--- a/Extensions/fonts/xrender-fonts.lisp
+++ b/Extensions/fonts/xrender-fonts.lisp
@@ -356,7 +356,10 @@
 
 (defparameter *families/faces* *dejavu-families/faces*)
 
-(defparameter *truetype-font-path* #p"/usr/share/fonts/truetype/ttf-dejavu/")
+(defparameter *truetype-font-path* (find-if #'probe-file
+					    '(#p"/usr/share/fonts/truetype/ttf-dejavu/"
+					      #p"/usr/share/fonts/TTF/"
+					      #p"/usr/share/fonts/")))
 
 (fmakunbound 'clim-clx::text-style-to-x-font)
 


### PR DESCRIPTION

Considering that ATOMIC-INCF, ATOMIC-DECF are not suppurted anymore I add two simple macros for defresource. 

The default location of ttf in archlinux is #p"/usr/share/fonts/TTF/".

