### PR TITLE
remove mirrored-sheet-mixin from basic-pane

### DIFF
--- a/Backends/CLX/frame-manager.lisp
+++ b/Backends/CLX/frame-manager.lisp
@@ -79,13 +79,42 @@
 ;;; frame-manager. However, in the CLX case, we don't expect there to
 ;;; be any CLX specific panes. CLX uses the default generic panes
 ;;; instead.
+
+;;; if the pane is a subclass of basic-pane and it is not mirrored we create a new class.
+(defun maybe-mirroring (concrete-pane-class)
+  (when (and (not (subtypep concrete-pane-class 'mirrored-sheet-mixin))
+	     (subtypep concrete-pane-class 'basic-pane))
+    (let* ((concrete-pane-class-symbol (if (typep concrete-pane-class 'class)
+                                          (class-name concrete-pane-class)
+                                          concrete-pane-class))
+	   (concrete-mirrored-pane-class (concatenate 'string
+						      "CLX-"
+						      (symbol-name concrete-pane-class-symbol)
+						      "-DUMMY"))
+	   (concrete-mirrored-pane-class-symbol (find-symbol concrete-mirrored-pane-class
+							     :clim-clx)))
+      ;;(format *debug-io* "use dummy mirrored class ~A~%" concrete-mirrored-pane-class)
+      (unless concrete-mirrored-pane-class-symbol
+	(setf concrete-mirrored-pane-class-symbol
+	      (intern concrete-mirrored-pane-class :clim-clx))
+	(eval
+	 `(defclass ,concrete-mirrored-pane-class-symbol
+	      (mirrored-sheet-mixin
+	       ,concrete-pane-class-symbol)
+	    ()
+	    (:metaclass ,(type-of (find-class concrete-pane-class-symbol))))))
+	;;(format *debug-io* "create class ~A~%" concrete-mirrored-pane-class-symbol))
+      (setf concrete-pane-class (find-class concrete-mirrored-pane-class-symbol))))
+  concrete-pane-class)
+
 (defmethod make-pane-1 ((fm clx-frame-manager) (frame application-frame) type &rest args)
   (apply #'make-instance
-	 (find-concrete-pane-class type)
+	 (maybe-mirroring (find-concrete-pane-class type))
 	 :frame frame
 	 :manager fm
 	 :port (port frame)
 	 args))
+
 
 (defmethod adopt-frame :before ((fm clx-frame-manager) (frame menu-frame))
   ;; Temporary kludge.

--- a/Backends/CLX/port.lisp
+++ b/Backends/CLX/port.lisp
@@ -435,11 +435,15 @@
   (port-lookup-mirror port sheet))
 
 (defmethod realize-mirror ((port clx-port) (sheet mirrored-sheet-mixin))
+  ;;mirrored-sheet-mixin is always in the top of the Class Precedence List
+  (%realize-mirror port sheet))
+
+(defmethod %realize-mirror ((port clx-port) (sheet basic-sheet))
   (realize-mirror-aux port sheet
                       :border-width 0
                       :map (sheet-enabled-p sheet)))
 
-(defmethod realize-mirror ((port clx-port) (sheet border-pane))
+(defmethod %realize-mirror ((port clx-port) (sheet border-pane))
   ;;(rotatef (medium-background (sheet-medium sheet)) (medium-foreground (sheet-medium sheet)))
   (realize-mirror-aux port sheet
 		      :border-width 0 ; (border-pane-width sheet)
@@ -447,7 +451,7 @@
 				    :structure-notify)
                       :map (sheet-enabled-p sheet)))
 
-(defmethod realize-mirror ((port clx-port) (sheet top-level-sheet-pane))
+(defmethod %realize-mirror ((port clx-port) (sheet top-level-sheet-pane))
   (let ((q (compose-space sheet)))
     (let ((frame (pane-frame sheet))
           (window (realize-mirror-aux port sheet
@@ -467,14 +471,14 @@
                             :WM_CLIENT_LEADER (list (xlib:window-id window))
                             :WINDOW 32))))
 
-(defmethod realize-mirror ((port clx-port) (sheet unmanaged-top-level-sheet-pane))
+(defmethod %realize-mirror ((port clx-port) (sheet unmanaged-top-level-sheet-pane))
   (realize-mirror-aux port sheet
 		      :override-redirect :on
                       :save-under :on
 		      :map nil
 		      :event-mask '(:structure-notify)))
 
-(defmethod realize-mirror ((port clx-port) (sheet menu-button-pane))
+(defmethod %realize-mirror ((port clx-port) (sheet menu-button-pane))
   (realize-mirror-aux port sheet
 		      :event-mask '(:exposure
 				    :key-press :key-release
@@ -486,7 +490,7 @@
 				    :owner-grab-button)
                       :map (sheet-enabled-p sheet)))
 
-(defmethod realize-mirror ((port clx-port) (sheet clim-stream-pane))
+(defmethod %realize-mirror ((port clx-port) (sheet clim-stream-pane))
   (realize-mirror-aux port sheet
 		      :event-mask '(:exposure
 				    :key-press :key-release

--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -817,7 +817,7 @@ order to produce a double-click")
 ;;; BASIC PANE
 
 (defclass basic-pane (standard-space-requirement-options-mixin
-                      sheet-parent-mixin mirrored-sheet-mixin
+                      sheet-parent-mixin 
                       pane)
   ((foreground       :initarg :foreground
                      :reader pane-foreground)


### PR DESCRIPTION
I'm working for a backend with a single top-level window. 
The first step was to remove MIRRORED-SHEET-MIXIN from the superclasses of BASIC-PANE. CLX backend creates a dummy class for each BASIC-PANE subclass.


