### PR TITLE
text-style-to-X-font: make function generic

### DIFF
--- a/Backends/CLX/port.lisp
+++ b/Backends/CLX/port.lisp
@@ -1030,10 +1030,11 @@
         (cons font-name (open-font (clx-port-display port) font-name)))
   font-name)
 
-(defun text-style-to-X-font (port text-style)
-  (let ((text-style (parse-text-style text-style)))
-    (text-style-mapping port text-style)
-    (cdr (gethash text-style (port-text-style-mappings port)))))
+(defgeneric text-style-to-X-font (port text-style)
+  (:method ((port t) (text-style t))
+    (let ((text-style (parse-text-style text-style)))
+      (text-style-mapping port text-style)
+      (cdr (gethash text-style (port-text-style-mappings port))))))
 
 ;;; The generic function PORT-CHARACTER-WIDTH might be intended to be
 ;;; common for all ports, but in fact, that symbol is in the CLIM-CLX

--- a/Extensions/fonts/xrender-fonts.lisp
+++ b/Extensions/fonts/xrender-fonts.lisp
@@ -366,8 +366,6 @@
 					      #p"/usr/share/fonts/TTF/"
 					      #p"/usr/share/fonts/")))
 
-(fmakunbound 'clim-clx::text-style-to-x-font)
-
 (defstruct truetype-device-font-name
   (font-file (error "missing argument"))
   (size      (error "missing argument")))


### PR DESCRIPTION
xrender-fonts from the truetype extensions specializes on the port and
text style while the text-style-to-X-font is an ordinary function by
default.

This was hacked out by calling FMAKUNBOUND and defining the
method (which implicitly created a generic function). Hack is removed in
favour of making a function generic and providing a default method.