### PR TITLE
input-editor: fix call to vector-push-extend

### DIFF
--- a/Libraries/Drei/input-editor.lisp
+++ b/Libraries/Drei/input-editor.lisp
@@ -409,8 +409,7 @@ for `type', or `object' if it isn't."
   ;; it.
   (let ((insertion (make-array 10 :adjustable t :fill-pointer 0)))
     (labels ((insert-object (object)
-               (vector-push-extend object insertion
-                                   (* (length insertion))))
+               (vector-push-extend object insertion))
              (insert-objects (objects)
                (setf insertion (adjust-array insertion
                                              (+ (length insertion)


### PR DESCRIPTION
vector-push-extend was called with the optional argument which could 0, what lead to the condition in the debugger preventing from intermixing some presentations and the S-expressions. This removes this optional argument.