### PR TITLE
Fix the mcclim-truetype on Debian 8.2.0

### DIFF
--- a/Extensions/fonts/fontconfig.lisp
+++ b/Extensions/fonts/fontconfig.lisp
@@ -77,8 +77,14 @@
           collect
           (cons (list (car family) (car face)) filename))))
 
+
 (defun autoconfigure-fonts ()
   (let ((map (build-font/family-map)))
-    (if map
+    (if (and map (support-map-p map))
         (setf *families/faces* map)
         (warn-about-unset-font-path))))
+
+(defun support-map-p (map)
+  (not (find-if #'(lambda (font-path)
+		    (string-equal "ttc" (pathname-type font-path)))
+		map :key #'cdr)))

--- a/Extensions/fonts/xrender-fonts.lisp
+++ b/Extensions/fonts/xrender-fonts.lisp
@@ -363,6 +363,7 @@
 
 (defparameter *truetype-font-path* (find-if #'probe-file
 					    '(#p"/usr/share/fonts/truetype/ttf-dejavu/"
+					      #p"/usr/share/fonts/truetype/dejavu/"
 					      #p"/usr/share/fonts/TTF/"
 					      #p"/usr/share/fonts/")))
 


### PR DESCRIPTION
On Debian 8.2.0, the `(mcclim-truetype::build-font/family-map)` will returns
```
(((:SERIF :ROMAN) . #P"/usr/share/fonts/truetype/arphic/uming.ttc")
 ((:SERIF :BOLD) . #P"/usr/share/fonts/truetype/arphic/uming.ttc")
 ((:SERIF :ITALIC) . #P"/usr/share/fonts/truetype/arphic/uming.ttc")
 ((:SERIF (:BOLD :ITALIC)) . #P"/usr/share/fonts/truetype/arphic/uming.ttc")
 ((:SANS-SERIF :ROMAN) . #P"/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc")
 ((:SANS-SERIF :BOLD) . #P"/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc")
 ((:SANS-SERIF :ITALIC) . #P"/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc")
 ((:SANS-SERIF (:BOLD :ITALIC))
  . #P"/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc")
 ((:FIX :ROMAN) . #P"/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc")
 ((:FIX :BOLD) . #P"/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc")
 ((:FIX :ITALIC) . #P"/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc")
 ((:FIX (:BOLD :ITALIC)) . #P"/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc"))
```
But ZPB-TTF doesn't support TTC file format, so when runs `(CLIM-DEMO::DEMODEMO)` it will cause bad magic value condition:
```
Bad magic value in font header: #x74746366 (expected #x00010000 or #x74727565)
   [Condition of type ZPB-TTF::BAD-MAGIC]

Restarts:
 0: [CHANGE-FONT-PATH] Retry with alternate truetype font path
 1: [RETRY] Retry SLIME REPL evaluation request.
 2: [*ABORT] Return to SLIME's top level.
 3: [ABORT] Abort thread (#<THREAD "repl-thread" RUNNING {10056080B3}>)

Backtrace:
  0: (ZPB-TTF::OPEN-FONT-LOADER-FROM-STREAM #<SB-SYS:FD-STREAM for "file /usr/share/fonts/truetype/wqy/wqy-zenhei.ttc" {10075043C3}>)
  1: (ZPB-TTF::OPEN-FONT-LOADER-FROM-FILE "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc")
  2: ((FLET SB-THREAD::WITH-MUTEX-THUNK :IN MCCLIM-TRUETYPE::MAKE-TRUETYPE-FACE))
  3: ((FLET #:WITHOUT-INTERRUPTS-BODY-647 :IN SB-THREAD::CALL-WITH-MUTEX))
  4: (SB-THREAD::CALL-WITH-MUTEX #<CLOSURE (FLET SB-THREAD::WITH-MUTEX-THUNK :IN MCCLIM-TRUETYPE::MAKE-TRUETYPE-FACE) {7FFFF4A5D72B}> #<SB-THREAD:MUTEX "zpb-font" owner: #<SB-THREAD:THREAD "repl-thread" RU..
  5: (MCCLIM-TRUETYPE::MAKE-TRUETYPE-FACE #<XLIB:DISPLAY :0 (The X.Org Foundation R11604000)> "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc" 24)
  6: ((FLET MCCLIM-TRUETYPE::F :IN CLIM-CLX::TEXT-STYLE-TO-X-FONT))
  7: (MCCLIM-TRUETYPE::INVOKE-WITH-TRUETYPE-PATH-RESTART #<CLOSURE (FLET MCCLIM-TRUETYPE::F :IN CLIM-CLX::TEXT-STYLE-TO-X-FONT) {10074F97BB}>)
  8: ((:METHOD CLIM-CLX::TEXT-STYLE-TO-X-FONT :AROUND (CLIM-CLX::CLX-PORT CLIM:STANDARD-TEXT-STYLE)) #<CLIM-CLX::CLX-PORT :HOST "" :DISPLAY-ID 0 {10066F1D73}> #<CLIM:STANDARD-TEXT-STYLE :SANS-SERIF :ROMAN ..
  9: ((:METHOD CLIM:TEXT-SIZE (CLIM-CLX::CLX-MEDIUM T)) #<unavailable argument> #<unavailable argument> :TEXT-STYLE #<unavailable argument> :START #<unavailable argument> :END #<unavailable argument>) [fas..
 10: ((:METHOD CLIM:COMPOSE-SPACE (CLIM:LABEL-PANE)) #<CLIM-CLX::CLX-LABEL-PANE-DUMMY "(Unnamed Pane)" {10074CBD23}> :WIDTH #<unused argument> :HEIGHT #<unused argument>) [fast-method]
 11: ((:METHOD CLIM:COMPOSE-SPACE :AROUND (CLIM-INTERNALS::LAYOUT-PROTOCOL-MIXIN)) #<CLIM-CLX::CLX-LABEL-PANE-DUMMY "(Unnamed Pane)" {10074CBD23}>) [fast-method]
 12: ((:METHOD CLIM:COMPOSE-SPACE :AROUND (CLIM-INTERNALS::SPACE-REQUIREMENT-OPTIONS-MIXIN)) #<CLIM-CLX::CLX-LABEL-PANE-DUMMY "(Unnamed Pane)" {10074CBD23}>) [fast-method]
 13: ((:METHOD CLIM-INTERNALS::VERTICALLY-CONTENT-SR** (CLIM-INTERNALS::BOX-LAYOUT-MIXIN T)) #<unavailable argument> #<CLIM-INTERNALS::BOX-CLIENT {10074F9093}>) [fast-method]
 14: ((:METHOD CLIM-INTERNALS::BOX-LAYOUT-MIXIN/VERTICALLY-COMPOSE-SPACE (CLIM-INTERNALS::BOX-LAYOUT-MIXIN)) #<CLIM-CLX::CLX-VRACK-PANE-DUMMY "(Unnamed Pane)" {10074F8863}>) [fast-method]
 15: ((:METHOD CLIM:COMPOSE-SPACE :AROUND (CLIM-INTERNALS::LAYOUT-PROTOCOL-MIXIN)) #<CLIM-CLX::CLX-VRACK-PANE-DUMMY "(Unnamed Pane)" {10074F8863}>) [fast-method]
 16: ((:METHOD CLIM:COMPOSE-SPACE :AROUND (CLIM-INTERNALS::SPACE-REQUIREMENT-OPTIONS-MIXIN)) #<CLIM-CLX::CLX-VRACK-PANE-DUMMY "(Unnamed Pane)" {10074F8863}>) [fast-method]
 17: ((:METHOD CLIM:COMPOSE-SPACE :AROUND (CLIM-INTERNALS::LAYOUT-PROTOCOL-MIXIN)) #<CLIM-CLX::CLX-TOP-LEVEL-SHEET-PANE-DUMMY CLIM-INTERNALS::TOP-LEVEL-SHEET {10074CAA63}>) [fast-method]
 18: ((:METHOD CLIM:COMPOSE-SPACE :AROUND (CLIM-INTERNALS::SPACE-REQUIREMENT-OPTIONS-MIXIN)) #<CLIM-CLX::CLX-TOP-LEVEL-SHEET-PANE-DUMMY CLIM-INTERNALS::TOP-LEVEL-SHEET {10074CAA63}>) [fast-method]
 19: ((:METHOD CLIM-CLX::%REALIZE-MIRROR (CLIM-CLX::CLX-PORT CLIM-INTERNALS::TOP-LEVEL-SHEET-PANE)) #<CLIM-CLX::CLX-PORT :HOST "" :DISPLAY-ID 0 {10066F1D73}> #<CLIM-CLX::CLX-TOP-LEVEL-SHEET-PANE-DUMMY CLIM..
 --more--
```
So this fix to use default Dejavu fonts when `(mcclim-truetype::build-font/family-map)` returns a map containing any .ttc file. After this fix, it will cause a warning when loading McCLIM:
```
NOTE:
* McCLIM was unable to configure itself automatically using
  fontconfig. Therefore you must configure it manually.
```
And use the `CONTINUE` restart, McCLIM will use default Dejavu fonts and demodemo works correctly.
In a OS that use ttf as default fonts will not be influenced from this fix and work correctly as before.