### PR TITLE
fix fontconfig on Debian

### DIFF
--- a/Extensions/fonts/fontconfig.lisp
+++ b/Extensions/fonts/fontconfig.lisp
@@ -79,6 +79,13 @@
 
 (defun autoconfigure-fonts ()
   (let ((map (build-font/family-map)))
-    (if map
+    (if (and map (support-map-p map))
         (setf *families/faces* map)
         (warn-about-unset-font-path))))
+
+(defun support-map-p (font-map)
+  (handler-case
+      (every #'(lambda (font)
+		 (zpb-ttf:with-font-loader (ignored (cdr font)) t))
+	     font-map)
+    (zpb-ttf::bad-magic () nil)))

--- a/Extensions/fonts/xrender-fonts.lisp
+++ b/Extensions/fonts/xrender-fonts.lisp
@@ -358,6 +358,7 @@
 
 (defparameter *truetype-font-path* (find-if #'probe-file
 					    '(#p"/usr/share/fonts/truetype/ttf-dejavu/"
+					      #p"/usr/share/fonts/truetype/dejavu/"
 					      #p"/usr/share/fonts/TTF/"
 					      #p"/usr/share/fonts/")))
 


### PR DESCRIPTION
This code is provided by @dkochmanski .Thanks for his help. After this fix, McCLIM demos can be run on Debian after use `CONTINUE` restart from a warning:
```
NOTE:
* McCLIM was unable to configure itself automatically using
  fontconfig. Therefore you must configure it manually.
```