### PR TITLE
Implement MEDIUM-DRAW-TEXT* when medium is an instance of STRING-STREAM

### DIFF
--- a/Core/clim-basic/graphics.lisp
+++ b/Core/clim-basic/graphics.lisp
@@ -888,6 +888,7 @@ position for the character."
                               start end
                               align-x align-y
                               toward-x toward-y transform-glyphs)
+  (declare (ignore x y start end align-x align-y toward-x toward-y transform-glyphs))
   (write-string string medium))
 
 ;;; Some image junk...

--- a/Core/clim-basic/graphics.lisp
+++ b/Core/clim-basic/graphics.lisp
@@ -884,6 +884,12 @@ position for the character."
 			       align-x align-y
 			       toward-x toward-y transform-glyphs))
 
+(defmethod medium-draw-text* ((medium string-stream) string x y
+                              start end
+                              align-x align-y
+                              toward-x toward-y transform-glyphs)
+  (write-string string medium))
+
 ;;; Some image junk...
 
 (defmethod medium-free-image-design ((sheet sheet-with-medium-mixin) design)


### PR DESCRIPTION
The implementation of `CLIM-INTERNALS:PRESENT-TO_STRING` calls `PRESENT` on a `STRING-STREAM`. Graphics functions that outputs text needs to have methods that handle this.

This fix implements such method for `MEDIUM-DRAW-TEXT*`, but these kinds of methods are probably needed for all the other gaphics functions.