### PR TITLE
Improve autoconfiguration of TTF fonts

### DIFF
--- a/Extensions/fonts/fontconfig.lisp
+++ b/Extensions/fonts/fontconfig.lisp
@@ -58,25 +58,16 @@
 * McCLIM was unable to configure itself automatically using
   fontconfig. Therefore you must configure it manually.~%"))
 
-(defparameter *fc-match-program*
-  (find-if #'probe-file
-	   '("/usr/bin/fc-match"
-	     "/usr/local/bin/fc-match"
-	     "/opt/X11/bin/fc-match")))
-
 (defun find-fontconfig-font (font-fc-name)
-  (and *fc-match-program*
-       (multiple-value-bind (output errors code)
-	   (uiop:run-program (list *fc-match-program* "-v" font-fc-name)
-			     :input nil :output :string :error-output nil
-			     :force-shell nil :ignore-error-status t)
-	 (declare (ignore errors))
-	 (if (not (zerop code))
-	     (progn
-	       (warn "~&fc-match failed with code ~D.~%" code)
-	       nil)
-	     (with-input-from-string (stream output)
-	       (parse-fontconfig-output stream))))))
+  (multiple-value-bind (output errors code)
+      (uiop:run-program (list "fc-match" "-v" font-fc-name)
+			:input nil :output :string :error-output nil
+			:force-shell t :ignore-error-status t)
+    (declare (ignore errors))
+    (if (not (zerop code))
+	(warn "~&fc-match failed with code ~D.~%" code)
+	(with-input-from-string (stream output)
+	  (parse-fontconfig-output stream)))))
 
 (defun fontconfig-name (family face) 
   (format nil "~A:~A" family face))

--- a/Extensions/fonts/xrender-fonts.lisp
+++ b/Extensions/fonts/xrender-fonts.lisp
@@ -360,7 +360,9 @@
 					    '(#p"/usr/share/fonts/truetype/ttf-dejavu/"
 					      #p"/usr/share/fonts/truetype/dejavu/"
 					      #p"/usr/share/fonts/TTF/"
-					      #p"/usr/share/fonts/")))
+					      #p"/usr/share/fonts/"
+					      #p"/opt/X11/share/fonts/TTF/"
+					      #p"/opt/X11/lib/X11/fonts/TTF/")))
 
 (defstruct truetype-device-font-name
   (font-file (error "missing argument"))


### PR DESCRIPTION
Out of the box, the current McCLIM seems to have some problems getting the truetype font configuration right, at least on Mac OS/X (10.11.6, El Capitan). This PR tries to improve on the situation slightly.

1. In `clim-clx::text-style-to-X-font`, the code examines the resolved pathname; if it is already absolute, it doesn't even try to `merge-pathname` it against `*truetype-font-path*`.
2. In `mcclim-truetype::find-fontconfig-font`, we use `uiop:run-program` now instead of the deprecated `asdf:run-shell-command`. Also, we try to use a fully qualified path for the `fc-match` program. I am not sure why that would be, but neither `run-shell-program` nor `run-program` (regardless of whether `:force-shell` is true) seems to be able to run `fc-match` otherwise.

I am not entirely sure, whether all of these changes are appropriate for all machines; in particular, I do not currently have access to Linux desktop machine, so I cannot test these changes on configurations other than my Mac right now. Feel free to request changes, if this PR breaks other environments. 