### PR TITLE
make mcclim-fonts system independent from clx backend

### DIFF
--- a/Backends/CLX/mcclim-clx.asd
+++ b/Backends/CLX/mcclim-clx.asd
@@ -19,4 +19,4 @@
 
 (defsystem #:mcclim-clx/pretty
   :depends-on (#:mcclim-clx
-               #:mcclim-fonts/truetype))
+               #:mcclim-clx-fonts))

--- a/Extensions/fonts/mcclim-clx-fonts.asd
+++ b/Extensions/fonts/mcclim-clx-fonts.asd
@@ -1,0 +1,5 @@
+
+(defsystem #:mcclim-clx-fonts
+  :depends-on (#:mcclim-fonts/truetype #:mcclim-clx)
+  :components
+  ((:file "xrender-fonts")))

--- a/Extensions/fonts/mcclim-fonts.asd
+++ b/Extensions/fonts/mcclim-fonts.asd
@@ -1,15 +1,13 @@
-
 #| dummy system to make Quicklisp happy |#
 (defsystem #:mcclim-fonts)
 
 (defsystem #:mcclim-fonts/truetype
-  :depends-on (#:mcclim-clx #:zpb-ttf #:cl-vectors #:cl-paths-ttf #:cl-aa #:alexandria)
-  :components
-  ((:static-file "README.md")
-   (:file "truetype-package")
-   (:file "xrender-fonts" :depends-on ("mcclim-native-ttf" "truetype-package" "fontconfig"))
-   (:file "fontconfig" :depends-on ("truetype-package"))
-   (:file "mcclim-native-ttf" :depends-on ("truetype-package"))))
+    :depends-on (#:clim-basic #:zpb-ttf #:cl-vectors #:cl-paths-ttf #:cl-aa #:alexandria)
+    :components
+    ((:static-file "README.md")
+     (:file "truetype-package")
+     (:file "fontconfig" :depends-on ("truetype-package"))
+     (:file "mcclim-native-ttf" :depends-on ("truetype-package"))))
 
 (defmethod perform :after ((o load-op)
                            (s (eql (find-system :mcclim-fonts/truetype))))

--- a/Extensions/fonts/mcclim-native-ttf.lisp
+++ b/Extensions/fonts/mcclim-native-ttf.lisp
@@ -84,10 +84,9 @@
 
 (defmethod print-object ((object truetype-font) stream)
   (print-unreadable-object (object stream :type t :identity nil)
-    (with-slots (font-loader size ascent descent) object      
-      (format stream "~W size=~A ascent=~A descent=~A" 
-              (zpb-ttf:name-entry-value :full-name font-loader)
-              size ascent descent))))
+    (with-slots (size ascent descent units->pixels) object      
+      (format stream " size=~A ascent=~A descent=~A units->pixels=~A"
+              size ascent descent units->pixels))))
 
 (defun glyph-pixarray (font char)
   "Render a character of 'face', returning a 2D (unsigned-byte 8) array


### PR DESCRIPTION
Hi Daniel,
I need to use mcclim-fonts without clx. I just split the asd file.
I also fix the printing of mcclim-font objects.

Alessandro