### PR TITLE
fix region-contains-position-p

### DIFF
--- a/Core/clim-basic/regions.lisp
+++ b/Core/clim-basic/regions.lisp
@@ -1224,7 +1224,7 @@
                       (when (<= y1 y y2)
                         (when (isum-member x isum)
                           (return t)))
-                      (when (> y y2)
+                      (when (< y y2)
                         (return nil)))
                     (standard-rectangle-set-bands self))
     nil))


### PR DESCRIPTION
Hi Daniel,
the solution that you proposed is fine.
I have seen that the bands are always ordered so we can quit if we y is smaller than y2.

The example "10) Clipping Region" of drawing tests uses this method.

Alessandro
