### PR TITLE
Update medium.lisp

### DIFF
--- a/Backends/Null/medium.lisp
+++ b/Backends/Null/medium.lisp
@@ -130,7 +130,6 @@
   (declare (ignore text-style char))
   1)
 
-;;; FIXME: this one is nominally backend-independent
 (defmethod text-style-width (text-style (medium null-medium))
   (text-style-character-width text-style medium #\m))
 


### PR DESCRIPTION
This fixme is not very accurate. As on Windows, there is an api for average character width for given text-style, not necessarily the width of `#\m`.