### PR TITLE
esa: don't leak generic function to clim package

### DIFF
--- a/Libraries/Drei/drei.lisp
+++ b/Libraries/Drei/drei.lisp
@@ -197,7 +197,7 @@ instances."))
   (require-minibuffer)
   (let ((item (handler-case
                   (accept
-                   `(command :command-table ,(command-table (drei-instance)))
+                   `(command :command-table ,(esa-command-table (drei-instance)))
                    ;; this gets erased immediately anyway
                    :prompt "" :prompt-mode :raw)
                 ((or command-not-accessible command-not-present) ()
@@ -259,7 +259,7 @@ instance will perform output to.")
 associated with the Drei instance. This may be NIL.")
    (%command-table :initform (make-instance 'drei-command-table
                                             :name 'drei-dispatching-table)
-                   :reader command-table
+                   :reader esa-command-table
                    :initarg :command-table
                    :type standard-command-table
                    :documentation "The command table used for

--- a/Libraries/Drei/packages.lisp
+++ b/Libraries/Drei/packages.lisp
@@ -30,6 +30,7 @@
   (:use :clim-lisp :flexichain :binseq :esa-utils)
   ;; Kludge to remove symbol conflicts.
   (:import-from :esa-io :buffer)
+  (:import-from :esa :esa-command-table)
   (:export #:buffer #:standard-buffer
            #:mark #:left-sticky-mark #:right-sticky-mark
            #:standard-left-sticky-mark #:standard-right-sticky-mark

--- a/Libraries/Drei/syntax.lisp
+++ b/Libraries/Drei/syntax.lisp
@@ -26,7 +26,7 @@
   ((%buffer :initarg :buffer :reader buffer)
    (%command-table :initarg :command-table
                    :initform (error "A command table has not been provided for this syntax")
-                   :reader command-table)
+                   :reader esa-command-table)
    (%updater-fns :initarg :updater-fns
                  :initform '()
                  :accessor updater-fns
@@ -45,7 +45,7 @@ on to a call to `update-syntax'."))
 `syntax'.")
   (:method-combination append :most-specific-last)
   (:method append ((syntax syntax))
-           (list (command-table syntax))))
+           (list (esa-command-table syntax))))
 
 (defun syntaxp (object)
   "Return T if `object' is an instance of a syntax, NIL

--- a/Libraries/ESA/packages.lisp
+++ b/Libraries/ESA/packages.lisp
@@ -91,6 +91,7 @@
            #:find-applicable-command-table
            #:esa-command-parser
            #:esa-partial-command-parser
+           #:esa-command-table
 
            #:gesture-matches-gesture-name-p #:meta-digit
            #:proper-gesture-p


### PR DESCRIPTION
Introduce esa-command-table generic function (instead of implicit one
command-table). This method is used in Drei, so we have to export it.