### PR TITLE
some clean up in clxv3

### DIFF
--- a/Backends/CLXv3/frame-manager.lisp
+++ b/Backends/CLXv3/frame-manager.lisp
@@ -39,6 +39,7 @@
 	      ,superclasses
 	    ()
 	    (:metaclass ,(type-of (find-class concrete-pane-class-symbol)))))
+	#+nil
 	(format *debug-io* "create class ~A~%" concrete-mirrored-pane-class-symbol))
       (setf concrete-pane-class (find-class concrete-mirrored-pane-class-symbol))))
   concrete-pane-class)

--- a/Backends/CLXv3/port.lisp
+++ b/Backends/CLXv3/port.lisp
@@ -27,12 +27,6 @@
 (defmethod clim-clx::realize-mirror ((port clxv3-port) (sheet mirrored-sheet-mixin))
   (clim-clx::%realize-mirror port sheet))
 
-(defmethod clim-clx::%realize-mirror ((port clxv3-port) (sheet basic-sheet))
-  (clim-clx::realize-mirror-aux port sheet
-		      :event-mask *event-mask*
-                      :border-width 0
-                      :map (sheet-enabled-p sheet)))
-
 (defmethod clim-clx::%realize-mirror ((port clxv3-port) (sheet top-level-sheet-pane))
   (let ((q (compose-space sheet)))
     (let ((frame (pane-frame sheet))

--- a/Backends/Standard/events.lisp
+++ b/Backends/Standard/events.lisp
@@ -2,7 +2,8 @@
 
 
 (defclass standard-event-port-mixin ()
-  ((pointer-grab-sheet :accessor pointer-grab-sheet :initform nil)))
+  ((pointer-grab-sheet :accessor pointer-grab-sheet :initform nil))
+  (:documentation "Standard event distribute for full-mirrored backend"))
 
 (defmethod distribute-event ((port standard-event-port-mixin) event)
   (let ((grab-sheet (pointer-grab-sheet port)))
@@ -25,7 +26,9 @@
        (error "Unknown event ~S received in DISTRIBUTE-EVENT" event)))))
 
 (defclass standard-handled-event-port-mixin (standard-event-port-mixin)
-  ((port-pointer-pressed-sheet :initform nil :accessor port-pointer-pressed-sheet)))
+  ((port-pointer-pressed-sheet :initform nil :accessor port-pointer-pressed-sheet))
+  (:documentation "Standard event distribute for single-mirrored backend, provides pointer-enter, 
+pointer-exit and grab-pointer for non mirrored sheets"))
 
 
 ;;;


### PR DESCRIPTION
the %realize-mirror for basic-sheet is surplus. They are not called as in all tests of clim:demodemo. Add a brief doc string for two event-port-mixin.
#128 