### PR TITLE
fix window-stream for single mirrored backends

### DIFF
--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -2845,6 +2845,8 @@ current background message was set."))
 		(eq (frame-state frame) :shrunk))
       (enable-frame frame))
     ;; Start a new thread to run the event loop, if necessary.
+    (let ((*application-frame* frame))
+      (stream-set-input-focus (slot-value frame 'stream)))
     #+clim-mp
     (unless input-buffer
       (clim-sys:make-process (lambda () (let ((*application-frame* frame))


### PR DESCRIPTION
fix for accepting-values with :own-window t for clxv3 and clxfb backends.