### PR TITLE
Increase Alexandria usage

### DIFF
--- a/Apps/Listener/dev-commands.lisp
+++ b/Apps/Listener/dev-commands.lisp
@@ -88,8 +88,9 @@
 	(lambda-list (clim-mop:method-lambda-list object))
 	(class-of-t (find-class t)))
     (format stream "~S ~{~S ~}(" name qualifiers)
-    (multiple-value-bind (required optional rest key key-present)
-	(climi::parse-lambda-list lambda-list)
+    (multiple-value-bind (required optional rest key allow-other-keys aux key-present)
+        (alexandria:parse-ordinary-lambda-list lambda-list)
+      (declare (ignore allow-other-keys aux))
       (loop
 	 for spec in specializers
 	 for arg in required
@@ -838,7 +839,7 @@ if you are interested in fixing this."))
 	  (return-from make-gf-specialized-ptype nil))))
     (unless (typep gf 'generic-function)
       (return-from make-gf-specialized-ptype nil))
-    (let ((required (climi::parse-lambda-list
+    (let ((required (alexandria:parse-ordinary-lambda-list
 		     (clim-mop::generic-function-lambda-list gf))))
       (loop
 	 for arg in required

--- a/Core/clim-basic/utils.lisp
+++ b/Core/clim-basic/utils.lisp
@@ -541,30 +541,6 @@ STREAM in the direction DIRECTION."
 		(values (cdr tail) t)))
      finally (return (values list nil))))
 
-;;; Why do I feel like I've written this function 8 million times
-;;; already?
-
-(defun parse-lambda-list (ll)
-  "Extract the parts of a function or method lambda list.
-
-  Returns values of required, &optional, &rest and &key
-  parameters. 5th value indicates that &key was seen"
-  (loop
-       with state = 'required
-       for var in ll
-       if (member var '(&optional &rest &key))
-        do (setq state var)
-       else if (eq state 'required)
-         collect var into required
-       else if (eq state '&optional)
-         collect var into optional
-       else if (eq state '&rest)
-         collect var into rest
-       else if (eq state '&key)
-         collect var into key
-       end
-       finally (return (values required optional rest key (eq state '&key)))))
-
 (defun rebind-arguments (arg-list)
   "Create temporary variables for non keywords in a list of
   arguments. Returns two values: a binding list for let, and a new

--- a/Core/clim-basic/utils.lisp
+++ b/Core/clim-basic/utils.lisp
@@ -580,16 +580,6 @@ STREAM in the direction DIRECTION."
      end
      finally (return (values bindings new-arg-list))))
 
-(defun make-keyword (obj)
-  "Turn OBJ into a keyword"
-  (etypecase obj
-    (keyword
-     obj)
-    (symbol
-     (intern (symbol-name obj) :keyword))
-    (string
-     (intern (string-upcase obj) :keyword))))
-
 ;;; Command name utilities that are useful elsewhere.
 
 (defun command-name-from-symbol (symbol)

--- a/Core/clim-basic/utils.lisp
+++ b/Core/clim-basic/utils.lisp
@@ -280,10 +280,6 @@ by the number of variables in VARS."
 		 (declare (ignorable ,vars))
 		 ,result-form)))))))
 
-(defun clamp (value min max)
-  "Clamps the value 'value' into the range [min,max]."
-  (max min (min max value)))
-  
 ;;;;
 ;;;; meta functions
 ;;;;

--- a/Core/clim-core/commands.lisp
+++ b/Core/clim-core/commands.lisp
@@ -1147,9 +1147,9 @@ examine the type of the command menu item to see if it is
       name-and-options
     (with-keywords-removed (options (:provide-output-destination-keyword))
       (if provide-output-destination-keyword
-	  (multiple-value-bind (required optional rest key key-supplied)
-	      (parse-lambda-list args)
-	    (declare (ignore required optional rest key))
+	  (multiple-value-bind (required optional rest key allow-other-keys aux key-supplied)
+	      (alexandria:parse-ordinary-lambda-list args)
+	    (declare (ignore required optional rest key allow-other-keys aux))
 	    (let* ((destination-arg '(output-destination 'output-destination
 				      :default nil))
 		   (new-args (if key-supplied

--- a/Libraries/ESA/packages.lisp
+++ b/Libraries/ESA/packages.lisp
@@ -25,8 +25,9 @@
 (defpackage :esa-utils
   (:use :clim-lisp :clim-mop :clim)
   (:shadowing-import-from :clim-lisp #:describe-object)
+  (:import-from #:alexandria
+		#:once-only)
   (:export #:with-gensyms
-           #:once-only
            #:unlisted
            #:fully-unlisted
            #:listed

--- a/Libraries/ESA/utils.lisp
+++ b/Libraries/ESA/utils.lisp
@@ -16,14 +16,6 @@
   `(let ,(mapcar #'(lambda (s) `(,s (gensym))) syms)
      ,@body))
 
-;;; Cribbed from PCL by Seibel
-(defmacro once-only ((&rest names) &body body)
-  (let ((gensyms (loop for n in names collect (gensym))))
-    `(let (,@(loop for g in gensyms collect `(,g (gensym))))
-       `(let (,,@(loop for g in gensyms for n in names collect ``(,,g ,,n)))
-          ,(let (,@(loop for n in names for g in gensyms collect `(,n ,g)))
-                ,@body)))))
-
 (defun unlisted (obj &optional (fn #'first))
   (if (listp obj)
       (funcall fn obj)

--- a/package.lisp
+++ b/package.lisp
@@ -2046,6 +2046,7 @@
   (:import-from :excl compile-system load-system)
   (:import-from #:alexandria
                 #:clamp
+                #:make-keyword
                 #:ensure-gethash)
   (:intern #:letf))
 

--- a/package.lisp
+++ b/package.lisp
@@ -2045,6 +2045,7 @@
   #+excl
   (:import-from :excl compile-system load-system)
   (:import-from #:alexandria
+                #:clamp
                 #:ensure-gethash)
   (:intern #:letf))
 


### PR DESCRIPTION
This is a first step towards removing local utility functions and macros and replacing them with implementations provided by the Alexandria library.

Functions and macros used: `CLAMP`, `PARSE-ORDINARY-LAMBDA`, `MAKE-KEYWORD` and `ONCE-ONLY`.