### PR TITLE
Use internet socket w/ localhost when connecting to CLX on Windows.

### DIFF
--- a/Backends/CLX/port.lisp
+++ b/Backends/CLX/port.lisp
@@ -71,6 +71,9 @@
 	    :protocol protocol))))
 
 (defun helpfully-automagic-clx-server-path ()
+  #+windows
+  (parse-clx-server-path '(:clx :host "localhost" :protocol :internet))
+  #-windows
   (restart-case (automagic-clx-server-path)
     (use-localhost ()
       :report "Use local unix display"

--- a/Core/clim-basic/clim-basic.asd
+++ b/Core/clim-basic/clim-basic.asd
@@ -1,6 +1,6 @@
 
 (defsystem #:clim-basic
-  :depends-on (#:clim-lisp #:spatial-trees (:version "flexichain" "1.5.1") #:bordeaux-threads #:trivial-garbage)
+  :depends-on (#:clim-lisp #:spatial-trees (:version "flexichain" "1.5.1") #:bordeaux-threads #:trivial-garbage #:trivial-features)
   :components
   ((:file "setf-star")
    (:file "decls" :depends-on ("setf-star"))


### PR DESCRIPTION
Also added :trivial-features to clim-basic.asd.

I tested this in Windows with SBCL and CCL and XMING server 6.9.0.31 (looks fairly out-of-date).  
SBCL works fine.  

I found that CLX w/ CCL is giving an error related to the X server version being incompatible.  I'm going to attempt to find out why SBCL works, but CCL doesn't on my machine, but I think that's outside of this issue.