### PR TITLE
with-drawing-options: call invoke-with-drawing-options directly

### DIFF
--- a/Core/clim-basic/graphics.lisp
+++ b/Core/clim-basic/graphics.lisp
@@ -181,8 +181,8 @@
 	      (declare (ignore ,cont-arg))
 	      ,@body))
        #-clisp (declare (dynamic-extent #',gcontinuation))
-       (apply #'invoke-with-drawing-options
-	      ,medium #',gcontinuation (list ,@drawing-options)))))
+       (invoke-with-drawing-options
+        ,medium #',gcontinuation ,@drawing-options))))
 
 (defmethod invoke-with-drawing-options ((medium medium) continuation
                                         &rest drawing-options


### PR DESCRIPTION
 * before, we would call (apply #'invoke-with-drawing-options
   ... (list ,@drawing-options). Now we just
   do (invoke-with-drawing-options ... ,@drawing-options).

   This avoids a compiler warning from SBCL about the third argument
   not being a constant (and why cons up a new list and call apply
   anyway?).