### PR TITLE
resurrect unsupported-bitmap-format

### DIFF
--- a/Extensions/bitmap-formats/bitmaps.lisp
+++ b/Extensions/bitmap-formats/bitmaps.lisp
@@ -4,8 +4,18 @@
 
 (in-package :clim-internals)
 
+(define-condition unsupported-bitmap-format (simple-error) ()
+  (:report (lambda (condition stream)
+	     (declare (ignore condition))
+	     (format stream "Unsupported bitmap format")))
+  (:documentation "This condition is signaled when trying to read a
+  bitmap file whose format is not supported." ))
+
 (defun opticl-read-bitmap-file (image-pathname)
-  (let* ((img (opticl:read-image-file image-pathname))
+  (let* ((img (handler-case
+                  (opticl:read-image-file image-pathname)
+                (error ()
+                  (error 'unsupported-bitmap-format))))
          (height (array-dimension img 0))
          (width (array-dimension img 1))
          (array (make-array (list height width)


### PR DESCRIPTION
 * and throw it as an error if the opticl:read-image-file call
   fails. Yes, there are other reasons this could fail, but this is
   less bad than not handling that error at all.