### PR TITLE
put sliderdemo in its own package

### DIFF
--- a/Examples/demodemo.lisp
+++ b/Examples/demodemo.lisp
@@ -78,7 +78,7 @@
 					(select-font))))
                    (make-demo-button "Tab Layout" 'tabdemo:tabdemo)
                    (make-demo-button "Summation" 'summation)
-                   (make-demo-button "Slider demo" 'sliderdemo)
+                   (make-demo-button "Slider demo" 'sliderdemo:sliderdemo)
                    (make-demo-button "German Towns"
                                      'town-example:town-example)
                    ;; this demo invokes the debugger

--- a/Examples/sliderdemo.lisp
+++ b/Examples/sliderdemo.lisp
@@ -19,7 +19,11 @@
 ;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 ;;; Boston, MA  02111-1307  USA.
 
-(in-package :clim-demo)
+(defpackage :sliderdemo
+  (:use :clim :clim-lisp :clim-tab-layout)
+  (:export :sliderdemo))
+
+(in-package :sliderdemo)
 
 (defparameter *calc* '(0))
 (defvar *text-field* nil)
@@ -75,6 +79,11 @@
 (defun find-text-field (frame)
   (first (member-if #'(lambda (gadget) (typep gadget 'text-field))
 		    (frame-current-panes frame))))
+
+(defgeneric sliderdemo-frame-top-level (frame &key command-parser
+                                                   command-unparser
+                                                   partial-command-parser
+                                                   prompt))
 
 (defmethod sliderdemo-frame-top-level
     ((frame application-frame)


### PR DESCRIPTION
 * it was clobbering some of calc's symbols. probably ok since
   sliderdemo appears to be just a cut-and-pasted version of calc,
   but, still, let's be on the safe side.