### PR TITLE
Bezier package improvements

### DIFF
--- a/Examples/drawing-tests.lisp
+++ b/Examples/drawing-tests.lisp
@@ -1401,8 +1401,8 @@
 ;;; currently broken and the test case is commented out for now.
 (define-drawing-test "16) Bezier Area" (stream)
     "Draws a single bezier-area. Currently this is quite slow and needs to be optimized. Also, the shape of the drawn bezier area is not particularly attractive."
-  (let* ((r1 (mcclim-bezier:make-bezier-area* '(100 100 200 200 300 200 400 100 300 50 200 50 100 100))))
-    (mcclim-bezier:draw-bezier-design* stream r1)))
+  (let* ((r1 (mcclim-bezier:make-bezier-area* '(120 160 35 200 220 280 220 40 180 160 160 180 120 160))))
+    (mcclim-bezier:draw-bezier-design* stream r1 :ink +cyan2+)))
 
 (define-drawing-test "16) Bezier Curve" (stream)
     "Draws a single bezier curve. This is currently broken as it should just draw the stroke of the bezier and instead renders the design as a bezier area."

--- a/Extensions/bezier/bezier.lisp
+++ b/Extensions/bezier/bezier.lisp
@@ -209,6 +209,8 @@
 			(transform-segment transformation segment))
 	       (%segments path))))
 
+;;; FIXME! This overrides region-equal in Core/clim-basic/regions.lisp
+;;; -- we probably don't want that!
 (defmethod region-equal ((p1 point) (p2 point))
   (let ((coordinate-epsilon (* #.(expt 2 10) double-float-epsilon)))
     (and (<= (abs (- (point-x p1) (point-x p2))) coordinate-epsilon)
@@ -611,7 +613,6 @@
     (transform-region transformation area)))
 
 (defun convolve-polygon-and-segment (area polygon segment first)
-  (declare (optimize debug))
   (let* ((points (polygon-points polygon))
 	 (sides (loop for (p0 p1) on (append (last points) points)
 		      until (null p1)
@@ -751,6 +752,9 @@
 		   (render-polygon result polygon 1 min-x min-y)))
 	result))))
 
+;;; FIXME this is bad -- we store the pixmap every time we draw it and
+;;; this becomes a huge leak if we draw a lot of bezier designs. OTOH,
+;;; this is only for the CLX backend right now. Still, should fix.
 (defparameter *pixmaps* (make-hash-table :test #'equal))
 
 (defun resolve-ink (medium)

--- a/Extensions/bezier/package.lisp
+++ b/Extensions/bezier/package.lisp
@@ -1,6 +1,25 @@
 
 (defpackage :mcclim-bezier
   (:use #:clim #:clim-lisp)
+
+  (:import-from #:clim-null
+                #:null-medium)
+
+  (:import-from #:mcclim-render
+                #:render-medium-mixin
+                #:make-path
+                #:line-to
+                #:curve-to
+                #:%medium-fill-paths
+                #:%medium-stroke-paths)
+
+  (:import-from #:clim-postscript
+                #:*transformation*
+                #:postscript-medium
+                #:postscript-medium-file-stream
+                #:postscript-actualize-graphics-state
+                #:write-coordinates)
+
   (:export #:bezier-design
            #:bezier-curve
            #:bezier-area
@@ -11,16 +30,16 @@
            #:areas
            #:positive-areas
            #:negative-areas
-           
+
            #:make-bezier-area
            #:make-bezier-area*
            #:make-bezier-curve
            #:make-bezier-curve*
-           
+
            #:segments
            #:p0 #:p1 #:p2 #:p3
            #:region-difference
            #:convolve-regions
-           
+
            #:draw-bezier-design*
            #:medium-draw-bezier-design*))


### PR DESCRIPTION
moves all the bezier code into mcclim-bezier and import-from's the appropriate symbols from the other packages, instead of doing (in-package :...) to get access to symbols from null, render, and postscript backends.

Also, fix up the bezier-area drawing-test example and add a couple FIXMEs.