### PR TITLE
fix translation of output-record

### DIFF
--- a/Extensions/bezier/bezier.lisp
+++ b/Extensions/bezier/bezier.lisp
@@ -102,11 +102,15 @@
     (bounding-rectangle* design)))
 
 (clim-sys:defmethod* (setf output-record-position) :around
-            (nx ny (record draw-bezier-design-output-record))
-  (let ((tr (make-instance 'climi::standard-translation :dx nx :dy ny)))
-    (multiple-value-prog1
-        (call-next-method))
-    (setf (output-record-translation record) tr)))
+                     (nx ny (record draw-bezier-design-output-record))
+  (climi::with-standard-rectangle* (:x1 x1 :y1 y1)
+      record
+    (let ((dx (- nx x1))
+          (dy (- ny y1)))
+      (let ((tr (make-instance 'climi::standard-translation :dx dx :dy dy)))
+        (multiple-value-prog1
+            (call-next-method))
+        (setf (output-record-translation record) tr)))))
 
 (defmethod replay-output-record :around ((record draw-bezier-design-output-record) stream
                                          &optional region x-offset y-offset)


### PR DESCRIPTION
 * we weren't taking into account the starting position of the design
   and were overtranslating it