### PR TITLE
tab-layout: draw-line* takes x1 y1 x2 y2 parameters, fix alloc-space

### DIFF
--- a/Examples/font-selector.lisp
+++ b/Examples/font-selector.lisp
@@ -160,9 +160,9 @@
              (y2 (+ y1 height))
              (ybase (+ y1 baseline)))
         (when ok
-	  (draw-line* stream 0 ybase pane-width ybase :ink +green+)
-	  (draw-line* stream 0 y1 pane-width y1 :ink +blue+)
-	  (draw-line* stream 0 y2 pane-width y2 :ink +blue+))
+	  (draw-line* stream 0 ybase (1- pane-width) ybase :ink +green+)
+	  (draw-line* stream 0 y1 (1- pane-width) y1 :ink +blue+)
+	  (draw-line* stream 0 y2 (1- pane-width) y2 :ink +blue+))
         (handler-case
 	    (draw-text* stream str x1 ybase :text-style style)
 	  (error (c)

--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -375,11 +375,9 @@ that the frame manager can customize the implementation."))
   (let ((old-page (tab-layout-enabled-page parent)))
     (unless (equal page old-page)
       (when old-page
-	(setf (sheet-enabled-p (tab-page-pane old-page)) nil))
-      (when page
-	(setf (sheet-enabled-p (tab-page-pane page)) t)))
+	(setf (sheet-enabled-p (tab-page-pane old-page)) nil)))
     (when page
-	(setf (sheet-enabled-p (tab-page-pane page)) t)))
+      (setf (sheet-enabled-p (tab-page-pane page)) t)))
   (call-next-method))
 
 (defun default-display-tab-header (tab-layout pane)

--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -422,8 +422,9 @@ that the frame manager can customize the implementation."))
              (space-requirement-combine #'max x y))
            (mapcar #'compose-space (sheet-children pane))
            :initial-value
-           (make-space-requirement :width 0 :min-width 0 :max-width 0
-                                   :height 0 :min-height 0 :max-height 0))))
+           (make-space-requirement
+            :min-width  0 :width  1 :max-width  clim:+fill+
+            :min-height 0 :height 1 :max-height clim:+fill+))))
 
 (defmethod allocate-space ((pane tab-layout-pane) width height)
   (let* ((header (tab-layout-header-pane pane))

--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -241,7 +241,7 @@ to the new page.  This function is a convenience wrapper; you can also
 push page objects directly into TAB-LAYOUT-PAGES and enable them using
 \(SETF TAB-LAYOUT-ENABLED-PAGE\)."
   (push page (tab-layout-pages tab-layout))
-  (when (or enable (tab-layout-enabled-page tab-layout))
+  (when (or enable (null (tab-layout-enabled-page tab-layout)))
     (setf (tab-layout-enabled-page tab-layout) page)))
 
 (defun switch-to-page (page)

--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -239,9 +239,9 @@ be returned."
   "Add PAGE at the left side of TAB-LAYOUT.  When ENABLE is true, move focus
 to the new page.  This function is a convenience wrapper; you can also
 push page objects directly into TAB-LAYOUT-PAGES and enable them using
-(SETF TAB-LAYOUT-ENABLED-PAGE)."
+\(SETF TAB-LAYOUT-ENABLED-PAGE\)."
   (push page (tab-layout-pages tab-layout))
-  (when enable
+  (when (or enable (tab-layout-enabled-page tab-layout))
     (setf (tab-layout-enabled-page tab-layout) page)))
 
 (defun switch-to-page (page)

--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -187,14 +187,8 @@ the TAB-LAYOUT implementation and specialized by its subclasses."))
   (alexandria:when-let ((page (sheet-to-page child)))
     (setf (slot-value parent 'pages) (remove page (tab-layout-pages parent))
           (tab-page-tab-layout page) nil)
-    (let* (;; tab-layout-enabled-page may be NIL!
-           (current-page (tab-layout-enabled-page parent))
-           (currentp (equal child (tab-page-pane current-page)))
-           (successor
-            (when currentp
-              (page-successor current-page))))
-      (when currentp
-        (setf (tab-layout-enabled-page parent) successor)))))
+    (when (eq page (tab-layout-enabled-page parent))
+      (setf (tab-layout-enabled-page parent) (page-successor page)))))
 
 (defun sheet-to-page (sheet)
   "For a SHEET that is a child of a tab layout, return the page corresponding

--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -436,7 +436,7 @@ that the frame manager can customize the implementation."))
 	(move-and-resize-sheet child 0 y width (- height y))
 	(allocate-space child width (- height y))))))
 
-(defmethod clim-tab-layout:note-tab-page-changed
+(defmethod note-tab-page-changed
     ((layout tab-layout-pane) page)
   (redisplay-frame-pane (pane-frame layout)
 			(tab-layout-header-pane layout)

--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -184,7 +184,7 @@ the TAB-LAYOUT implementation and specialized by its subclasses."))
       (sheet-adopt-child parent (tab-page-pane page)))
     ;; ensure that at least one page is enabled
     (when (null (tab-layout-enabled-page parent))
-      (setf (tab-layout-enabled-page parent) (car add)))))
+      (setf (tab-layout-enabled-page parent) (car (tab-layout-pages parent))))))
 
 (defmethod sheet-disown-child :before ((parent tab-layout) child &key errorp)
   (declare (ignore errorp))
@@ -192,7 +192,7 @@ the TAB-LAYOUT implementation and specialized by its subclasses."))
     (setf (slot-value parent 'pages) (remove page (tab-layout-pages parent))
           (tab-page-tab-layout page) nil)
     (when (eq page (tab-layout-enabled-page parent))
-      (setf (tab-layout-enabled-page parent) (page-successor page)))))
+      (setf (tab-layout-enabled-page parent) (car (tab-layout-pages parent))))))
 
 (defun sheet-to-page (sheet)
   "For a SHEET that is a child of a tab layout, return the page corresponding
@@ -223,13 +223,6 @@ be returned."
 
 (defmethod note-tab-page-changed ((layout tab-layout) page)
   nil)
-
-(defun page-successor (page)
-  "The page we should enable when PAGE is currently enabled but gets removed."
-  (loop for (a b c) on (tab-layout-pages (tab-page-tab-layout page)) do
-	(cond
-	  ((eq a page) (return b))
-	  ((eq b page) (return (or c a))))))
 
 (defun note-tab-page-enabled (page)
   (let ((callback (tab-page-enabled-callback page)))

--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -422,17 +422,13 @@ that the frame manager can customize the implementation."))
 
 (defmethod compose-space ((pane tab-layout-pane) &key width height)
   (declare (ignore width height))
-  (let ((q (compose-space (tab-layout-header-pane pane))))
-    (space-requirement+*
-     (reduce (lambda (x y)
-	       (space-requirement-combine #'max x y))
-	     (mapcar #'compose-space (sheet-children pane))
-	     :initial-value
-	     (make-space-requirement :width 0 :min-width 0 :max-width 0
-				     :height 0 :min-height 0 :max-height 0))
-     :height (space-requirement-height q)
-     :min-height (space-requirement-min-height q)
-     :max-height (space-requirement-max-height q))))
+  (space-requirement+*
+   (reduce (lambda (x y)
+             (space-requirement-combine #'max x y))
+           (mapcar #'compose-space (sheet-children pane))
+           :initial-value
+           (make-space-requirement :width 0 :min-width 0 :max-width 0
+                                   :height 0 :min-height 0 :max-height 0))))
 
 (defmethod allocate-space ((pane tab-layout-pane) width height)
   (let* ((header (tab-layout-header-pane pane))

--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -402,7 +402,7 @@ that the frame manager can customize the implementation."))
   (draw-line* pane
 	      0
 	      17
-	      (slot-value pane 'climi::current-width)
+              (1- (climi::pane-current-width pane))
 	      17
 	      :ink +black+)
   (mapc (lambda (page)

--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -440,8 +440,4 @@ that the frame manager can customize the implementation."))
     ((layout tab-layout-pane) page)
   (redisplay-frame-pane (pane-frame layout)
 			(tab-layout-header-pane layout)
-			#+NIL
-			(car (sheet-children
-			      (car (sheet-children
-				    (tab-layout-header-pane layout)))))
 			:force-p t))

--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -180,7 +180,11 @@ the TAB-LAYOUT implementation and specialized by its subclasses."))
     ;; add new pages:
     (dolist (page add)
       (setf (tab-page-tab-layout page) parent)
-      (sheet-adopt-child parent (tab-page-pane page)))))
+      (setf (sheet-enabled-p (tab-page-pane page)) nil)
+      (sheet-adopt-child parent (tab-page-pane page)))
+    ;; ensure that at least one page is enabled
+    (when (null (tab-layout-enabled-page parent))
+      (setf (tab-layout-enabled-page parent) (car add)))))
 
 (defmethod sheet-disown-child :before ((parent tab-layout) child &key errorp)
   (declare (ignore errorp))
@@ -241,7 +245,7 @@ to the new page.  This function is a convenience wrapper; you can also
 push page objects directly into TAB-LAYOUT-PAGES and enable them using
 \(SETF TAB-LAYOUT-ENABLED-PAGE\)."
   (push page (tab-layout-pages tab-layout))
-  (when (or enable (null (tab-layout-enabled-page tab-layout)))
+  (when enable
     (setf (tab-layout-enabled-page tab-layout) page)))
 
 (defun switch-to-page (page)


### PR DESCRIPTION
Previously we have taken pane width as x2. Since we count from 0,
(width,17) was one more than last pixel on the pane what caused
alloc-space to make the pane bigger. i.e pane width is 5, then last
point is (4,y).

cosmetic: use accessor instead of raw slot value.