### PR TITLE
Bezier render 2

### DIFF
--- a/Backends/CLX/medium.lisp
+++ b/Backends/CLX/medium.lisp
@@ -1215,7 +1215,7 @@ time an indexed pattern is drawn.")
       (unless pixmap
 	(setf pixmap (compute-rgb-image-pixmap da image))
 	(when (climi::image-alpha-p image)
-	  (setf mask (compute-rgb-image-mask da image)))
+         (setf mask (compute-rgb-image-mask da image)))
 	(setf (slot-value design 'climi::medium-data) (list pixmap mask)))
       (multiple-value-bind (x y)
 	  (transform-position

--- a/Core/clim-basic/graphics.lisp
+++ b/Core/clim-basic/graphics.lisp
@@ -895,7 +895,9 @@ position for the character."
       (when medium
 	(medium-free-image-design medium design))
       (setf medium current-medium)
-      (setf medium-data nil))))
+      #+nil
+      (when medium-data
+        (setf (car medium-data) nil)))))
 
 (defmethod medium-draw-image-design*
     ((medium sheet-with-medium-mixin) design x y)

--- a/Extensions/bezier/mcclim-bezier.asd
+++ b/Extensions/bezier/mcclim-bezier.asd
@@ -10,6 +10,6 @@
 
 (defsystem #:mcclim-bezier
   :description "Support for various bezier curves in McCLIM."
-  :depends-on (#:clim #:mcclim-null #:mcclim-render)
+  :depends-on (#:clim #:mcclim-null #:mcclim-render #:mcclim-raster-image)
   :components ((:file "package")
                (:file "bezier")))


### PR DESCRIPTION
This branch uses the mcclim-raster-image routines to draw bezier shapes on the CLX backend. Still not the ideal approach, but a temporary stopgap that makes rendering less bad.