### PR TITLE
Bezier clx draw rewrite

### DIFF
--- a/Examples/clim-fig.lisp
+++ b/Examples/clim-fig.lisp
@@ -31,6 +31,14 @@
   (setf (gadget-value (clim-fig-status *application-frame*))
 	string))
 
+(defun bezier-rounded-rectangle-coords (x1 y1 x2 y2 x-radius &optional (y-radius x-radius))
+  (mcclim-bezier:relative-to-absolute-coord-seq
+   (list x1 y1 x-radius (- y-radius)
+         (- x-radius)  (- y-radius) (- x2 x1) 0 x-radius y-radius
+         x-radius (- y-radius) 0 (- y2 y1) (- x-radius) y-radius
+         x-radius y-radius (- x1 x2) 0 (- x-radius) (- y-radius)
+         (- x-radius) y-radius 0 (- y1 y2))))
+
 (defun draw-figure (pane x y x1 y1 &key fastp cp-x1 cp-y1 cp-x2 cp-y2)
   (with-slots (line-style current-color fill-mode constrict-mode)
       *application-frame*
@@ -77,18 +85,33 @@
 			"[Use the middle and right mouse button to set control points]"
 			0
 			20))
-	  (let* ((cp-x1 (or cp-x1 x))
-		 (cp-y1 (or cp-y1 y1))
-		 (cp-x2 (or cp-x2 x1))
-		 (cp-y2 (or cp-y2 y))
-		 (design (mcclim-bezier::make-bezier-thing*
-                          'mcclim-bezier:bezier-area
-			  (list x y cp-x1 cp-y1 cp-x2 cp-y2 x1 y1))))
-            (unless (or (= x cp-x1 x1 cp-x2)
-                        (= y cp-y1 y1 cp-y2)) ; Don't draw null beziers.
-              (mcclim-bezier:draw-bezier-design* pane design)
-              (draw-line* pane x y cp-x1 cp-y1 :ink +red+)
-              (draw-line* pane x1 y1 cp-x2 cp-y2 :ink +blue+))))))))
+          (if fill-mode
+              (let* ((cp-x1 (or cp-x1 x))
+                     (cp-y1 (or cp-y1 y1))
+                     (cp-x2 (or cp-x2 x1))
+                     (cp-y2 (or cp-y2 y)))
+                (unless (or (= x cp-x1 x1 cp-x2)
+                            (= y cp-y1 y1 cp-y2)) ; Don't draw null beziers.
+                  (let ((design (mcclim-bezier::make-bezier-area*
+                                 (bezier-rounded-rectangle-coords cp-x1 cp-y1
+                                                                  cp-x2 cp-y2
+                                                                  (/ (min (abs (- cp-y2 cp-y1))
+                                                                          (abs (- cp-x2 cp-x1)))
+                                                                     3)))))
+                    (mcclim-bezier:draw-bezier-design* pane design :ink current-color))
+                  (draw-line* pane x y cp-x1 cp-y1 :ink +red+)
+                  (draw-line* pane x1 y1 cp-x2 cp-y2 :ink +blue+)))
+              (let* ((cp-x1 (or cp-x1 x))
+                     (cp-y1 (or cp-y1 y1))
+                     (cp-x2 (or cp-x2 x1))
+                     (cp-y2 (or cp-y2 y))
+                     (design (mcclim-bezier::make-bezier-curve*
+                              (list x y cp-x1 cp-y1 cp-x2 cp-y2 x1 y1))))
+                (unless (or (= x cp-x1 x1 cp-x2)
+                            (= y cp-y1 y1 cp-y2)) ; Don't draw null beziers.
+                  (mcclim-bezier:draw-bezier-design* pane design :ink current-color)
+                  (draw-line* pane x y cp-x1 cp-y1 :ink +red+)
+                  (draw-line* pane x1 y1 cp-x2 cp-y2 :ink +blue+)))))))))
 
 (defun signum-1 (value)
   (if (zerop value)

--- a/Examples/clim-fig.lisp
+++ b/Examples/clim-fig.lisp
@@ -31,14 +31,6 @@
   (setf (gadget-value (clim-fig-status *application-frame*))
 	string))
 
-(defun bezier-rounded-rectangle-coords (x1 y1 x2 y2 x-radius &optional (y-radius x-radius))
-  (mcclim-bezier:relative-to-absolute-coord-seq
-   (list x1 y1 x-radius (- y-radius)
-         (- x-radius)  (- y-radius) (- x2 x1) 0 x-radius y-radius
-         x-radius (- y-radius) 0 (- y2 y1) (- x-radius) y-radius
-         x-radius y-radius (- x1 x2) 0 (- x-radius) (- y-radius)
-         (- x-radius) y-radius 0 (- y1 y2))))
-
 (defun draw-figure (pane x y x1 y1 &key fastp cp-x1 cp-y1 cp-x2 cp-y2)
   (with-slots (line-style current-color fill-mode constrict-mode)
       *application-frame*
@@ -93,11 +85,7 @@
                 (unless (or (= x cp-x1 x1 cp-x2)
                             (= y cp-y1 y1 cp-y2)) ; Don't draw null beziers.
                   (let ((design (mcclim-bezier::make-bezier-area*
-                                 (bezier-rounded-rectangle-coords cp-x1 cp-y1
-                                                                  cp-x2 cp-y2
-                                                                  (/ (min (abs (- cp-y2 cp-y1))
-                                                                          (abs (- cp-x2 cp-x1)))
-                                                                     3)))))
+                                 (list x y cp-x1 cp-y1 cp-x2 cp-y2 x1 y1 x1 y1 x y x y))))
                     (mcclim-bezier:draw-bezier-design* pane design :ink current-color))
                   (draw-line* pane x y cp-x1 cp-y1 :ink +red+)
                   (draw-line* pane x1 y1 cp-x2 cp-y2 :ink +blue+)))

--- a/Examples/drawing-tests.lisp
+++ b/Examples/drawing-tests.lisp
@@ -1421,8 +1421,6 @@
          (r3 (mcclim-bezier:region-difference r1 r2))
          (r4 (mcclim-bezier:make-bezier-curve* (list 20 150 20 80 90 110 90 170 90 220 140 210 140 140)))
          (r5 (mcclim-bezier:convolve-regions r2 r4)))
-    (mcclim-bezier:draw-bezier-design* stream r1)
-    (mcclim-bezier:draw-bezier-design* stream r2)
     (mcclim-bezier:draw-bezier-design* stream r3)
     (mcclim-bezier:draw-bezier-design* stream r4
                                        :line-thickness 12
@@ -1541,6 +1539,13 @@
           (mcclim-bezier:draw-bezier-design* stream design
                                              :line-thickness 16
                                              :ink +pink+))))))
+
+(define-drawing-test "16) Bezier Difference" (stream)
+    "Draws a single bezier difference"
+  (let* ((r1 (mcclim-bezier:make-bezier-area* '(100 100 200 200 300 200 400 100 300 50 200 50 100 100)))
+         (r2 (mcclim-bezier:make-bezier-area* '(150 100 200 120 300 150 350 100 300 80 200 80 150 100)))
+         (r3 (mcclim-bezier:region-difference r1 r2)))
+    (mcclim-bezier:draw-bezier-design* stream r3)))
 
 (defun convert-postscript-file (file &key svg)
   (let ((result (uiop:run-program `( "ps2pdf" ,(uiop:unix-namestring file)))))

--- a/Extensions/bezier/bezier.lisp
+++ b/Extensions/bezier/bezier.lisp
@@ -849,10 +849,8 @@ second curve point, yielding (200 50)."
 
 ;;; CLX Backend
 
-(defun %clx-medium-draw-bezier-design (medium design &key filled)
-  (let* ((tr (sheet-native-transformation (medium-sheet medium)))
-         (design (transform-region tr design))
-         (poly (polygonalize design))
+(defun bezier-region-to-coord-vec (region)
+  (let* ((poly (polygonalize region))
          (points (polygon-points poly))
          (coord-vec (make-array 4 :fill-pointer 0)))
     (map nil (lambda (point)
@@ -860,6 +858,12 @@ second curve point, yielding (200 50)."
                  (vector-push-extend (clim-clx::round-coordinate x) coord-vec)
                  (vector-push-extend (clim-clx::round-coordinate y) coord-vec)))
          points)
+    coord-vec))
+
+(defun %clx-medium-draw-bezier-design (medium design &key filled)
+  (let* ((tr (sheet-native-transformation (medium-sheet medium)))
+         (region (transform-region tr design))
+         (coord-vec (bezier-region-to-coord-vec region)))
     (clim-clx::with-clx-graphics () medium
       (xlib:draw-lines clim-clx::mirror clim-clx::gc coord-vec :fill-p filled))))
 
@@ -874,11 +878,63 @@ second curve point, yielding (200 50)."
     (medium-draw-bezier-design* medium area)))
 
 (defmethod medium-draw-bezier-design* ((medium clim-clx::clx-medium) (design bezier-difference))
-  (dolist (area (positive-areas design))
-    (medium-draw-bezier-design* medium area))
-  (with-drawing-options (medium :ink +background-ink+)
-    (dolist (area (negative-areas design))
-      (medium-draw-bezier-design* medium area))))
+  (multiple-value-bind (min-x min-y max-x max-y)
+      (bounding-rectangle* design)
+    (let ((imin-x (floor min-x))
+          (imin-y (floor min-y))
+          (imax-x (ceiling max-x))
+          (imax-y (ceiling max-y)))
+      (let ((tr (make-instance 'climi::standard-translation :dx (- imin-x)  :dy (- imin-y))))
+        (let ((width (- imax-x imin-x))
+              (height (- imax-y imin-y)))
+          (let ((drawable (clim-clx::sheet-xmirror (medium-sheet medium))))
+            (with-slots ((gc clim-clx::gc)) medium
+              ;; 1. save the clipmask, clip-x-origin, and clip-y-origin
+              (let ((old-clip-mask (xlib:gcontext-clip-mask gc))
+                    (old-clip-x (xlib:gcontext-clip-x gc))
+                    (old-clip-y (xlib:gcontext-clip-y gc)))
+                ;; 2. create a 1-bit region that is the size of the bezier
+                ;; difference (the clip-pixmap)
+                (let* ((mask-pixmap (xlib:create-pixmap :drawable drawable
+                                                        :width width 
+                                                        :height height
+                                                        :depth 1))
+                       (mask-gc (xlib:create-gcontext :drawable mask-pixmap
+                                                      :foreground 1
+                                                      :background 0)))
+                  ;; 3. for each of the positive areas, draw 1s in the
+                  ;; clip-pixmap for the corresponding shape
+                  (setf (xlib:gcontext-foreground mask-gc) 1)
+                  (dolist (area (positive-areas design))
+                    (let ((t-area (transform-region tr area)))
+                      (let ((coord-vec (bezier-region-to-coord-vec t-area)))
+                        (xlib:draw-lines mask-pixmap mask-gc coord-vec :fill-p t))))
+                  ;; 4. for each of the negative areas, draw 0s in the
+                  ;; clip-pixmap for the corresponding shape
+                  (setf (xlib:gcontext-foreground mask-gc) 0)
+                  (dolist (area (negative-areas design))
+                    (let ((t-area (transform-region tr area)))
+                      (let ((coord-vec (bezier-region-to-coord-vec t-area)))
+                        (xlib:draw-lines mask-pixmap mask-gc coord-vec :fill-p t))))
+                  ;; 5. set the clipmask, clip-x-origin, and clip-y-origin
+                  (setf (xlib:gcontext-clip-mask gc :unsorted) mask-pixmap
+                        (xlib:gcontext-clip-x gc) imin-x
+                        (xlib:gcontext-clip-y gc) imin-y)
+                  ;; 6. actually do the (masked) drawing
+                  (dolist (area (positive-areas design))
+                    (let* ((tr (sheet-native-transformation (medium-sheet medium)))
+                           (region (transform-region tr area))
+                           (coord-vec (bezier-region-to-coord-vec region)))
+                      (clim-clx::with-clx-graphics () medium
+                        (xlib:draw-lines clim-clx::mirror clim-clx::gc coord-vec :fill-p t))))
+                  ;; 7. restore things on the way back out
+                  ;; reset the clipmask, clip-x-origin, and clip-y-origin to their original values
+                  (setf (xlib:gcontext-clip-mask gc) old-clip-mask
+                        (xlib:gcontext-clip-x gc) old-clip-x
+                        (xlib:gcontext-clip-y gc) old-clip-y)
+                  ;; 8. free the clipmask
+                  (xlib:free-gcontext mask-gc)
+                  (xlib:free-pixmap mask-pixmap))))))))))
 
 
 ;;; NULL backend support


### PR DESCRIPTION
Now we properly set a pixmap-based mask based on the positive and negative areas of a bezier difference when drawing with the CLX backend.