### PR TITLE
fix symbols in mcclim-image package

### DIFF
--- a/Extensions/image/clx-image.lisp
+++ b/Extensions/image/clx-image.lisp
@@ -34,7 +34,7 @@
 	      (xlib:copy-area pixmap gcontext 0 0 width height
 			      da x y))))))))
 
-(defmethod climi::medium-free-image-design
+(defmethod mcclim-image:medium-free-image-design
     ((medium clx-medium) (design mcclim-image:rgb-image-design))
   (destructuring-bind (&optional pixmap mask)
       (slot-value design 'mcclim-image::medium-data)

--- a/package.lisp
+++ b/package.lisp
@@ -889,7 +889,6 @@
    #:make-pane                          ;function
    #:make-pane-1                        ;generic function
    #:make-pattern                       ;function
-   #:make-pattern-from-bitmap-file      ;function
    #:make-point                         ;function
    #:make-polygon                       ;function
    #:make-polygon*                      ;function
@@ -1946,7 +1945,12 @@
    #:bitmap-format
    #:*default-vertical-scroll-bar-position*
 
-   #:find-frame-type))
+   #:find-frame-type
+   ;; images
+   #:rgb-image
+   #:rgb-pattern
+   #:xpm-parse-file
+   #:make-pattern-from-bitmap-file))
 
 ;;; Symbols that must be defined by a backend.
 ;;;


### PR DESCRIPTION
The previous commit broke a few applications: spectacle and sudoku.
