### PR TITLE
Output recording coord seq mixin

### DIFF
--- a/Backends/CLX/medium.lisp
+++ b/Backends/CLX/medium.lisp
@@ -847,14 +847,17 @@ time an indexed pattern is drawn.")
 				(medium-sheet medium))
                                position-seq)
     (with-clx-graphics () medium
-      (loop
-	 for (left top right bottom) on position-seq by #'cddddr
-	 for min-x = (round-coordinate left)
-	 for max-x = (round-coordinate right)
-	 for min-y = (round-coordinate top)
-	 for max-y = (round-coordinate bottom)
-	 nconcing (list min-x min-y (- max-x min-x) (- min-y max-y)) into points
-	 finally (xlib:draw-rectangles mirror gc points filled)))))
+      (let ((points (make-array 4 :fill-pointer 0)))
+        (do-sequence ((left top right bottom) position-seq)
+          (let ((min-x (round-coordinate left))
+                (max-x (round-coordinate right))
+                (min-y (round-coordinate top))
+                (max-y (round-coordinate bottom)))
+            (vector-push-extend min-x points)
+            (vector-push-extend min-y points)
+            (vector-push-extend (- max-x min-x) points)
+            (vector-push-extend (- max-y min-y) points)))
+        (xlib:draw-rectangles mirror gc points filled)))))
 
 ;;; Round the parameters of the ellipse so that it occupies the expected pixels
 (defmethod medium-draw-ellipse* ((medium clx-medium) center-x center-y

--- a/Core/clim-basic/recording.lisp
+++ b/Core/clim-basic/recording.lisp
@@ -1207,12 +1207,8 @@ were added."
 (defmethod match-output-records-1 and ((record coord-seq-mixin)
 				       &key (coord-seq nil coord-seq-p))
   (or (null coord-seq-p)
-      (let* ((my-coord-seq (slot-value record 'coord-seq))
-	     (len (length my-coord-seq)))
-	(and (eql len (length coord-seq))
-	     (loop for elt1 across my-coord-seq
-		   for elt2 across coord-seq
-		   always (coordinate= elt1 elt2))))))
+      (let* ((my-coord-seq (slot-value record 'coord-seq)))
+        (sequence= my-coord-seq coord-seq #'coordinate=))))
 
 (defmacro generate-medium-recording-body (class-name method-name args)
   (let ((arg-list (loop for arg in args

--- a/Core/clim-basic/recording.lisp
+++ b/Core/clim-basic/recording.lisp
@@ -1195,14 +1195,8 @@ were added."
                     coords))))))
 
 (defun sequence= (seq1 seq2 &optional (test 'equal))
-  (when (= (length seq1) (length seq2))
-    (map nil
-         (lambda (a b)
-           (unless (funcall test a b)
-             (return-from sequence= nil)))
-         seq1
-         seq2)
-    t))
+  (and (= (length seq1) (length seq2))
+       (every test seq1 seq2)))
 
 (defmethod match-output-records-1 and ((record coord-seq-mixin)
 				       &key (coord-seq nil coord-seq-p))

--- a/Core/clim-basic/recording.lisp
+++ b/Core/clim-basic/recording.lisp
@@ -1184,7 +1184,7 @@ were added."
 	  (coords (slot-value record 'coord-seq)))
       (multiple-value-prog1
 	  (call-next-method)
-        (let (odd)
+        (let ((odd nil))
           (map-into coords
                     (lambda (val)
                       (prog1
@@ -1195,7 +1195,7 @@ were added."
                     coords))))))
 
 (defun sequence= (seq1 seq2 &optional (test 'equal))
-  (when (eql (length seq1) (length seq2))
+  (when (= (length seq1) (length seq2))
     (map nil
          (lambda (a b)
            (unless (funcall test a b)

--- a/Core/clim-basic/recording.lisp
+++ b/Core/clim-basic/recording.lisp
@@ -1184,10 +1184,25 @@ were added."
 	  (coords (slot-value record 'coord-seq)))
       (multiple-value-prog1
 	  (call-next-method)
-	(loop for i from 0 below (length coords) by 2
-	      do (progn
-		   (incf (aref coords i) dx)
-		   (incf (aref coords (1+ i)) dy)))))))
+        (let (odd)
+          (map-into coords
+                    (lambda (val)
+                      (prog1
+                          (if odd
+                              (incf val dy)
+                              (incf val dx))
+                        (setf odd (not odd))))
+                    coords))))))
+
+(defun sequence= (seq1 seq2 &optional (test 'equal))
+  (when (eql (length seq1) (length seq2))
+    (map nil
+         (lambda (a b)
+           (unless (funcall test a b)
+             (return-from sequence= nil)))
+         seq1
+         seq2)
+    t))
 
 (defmethod match-output-records-1 and ((record coord-seq-mixin)
 				       &key (coord-seq nil coord-seq-p))

--- a/Core/clim-basic/recording.lisp
+++ b/Core/clim-basic/recording.lisp
@@ -1376,8 +1376,8 @@ were added."
 	 (coord-seq-bounds coord-seq 0))
 	((eq (line-style-joint-shape line-style) :round)
 	 (coord-seq-bounds coord-seq border))
-	(t (let* ((x1 (svref coord-seq 0))
-		  (y1 (svref coord-seq 1))
+	(t (let* ((x1 (elt coord-seq 0))
+		  (y1 (elt coord-seq 1))
 		  (min-x x1)
 		  (min-y y1)
 		  (max-x x1)
@@ -1392,13 +1392,13 @@ were added."
 				   final-xn final-yn
 				   initial-index final-index)
 		 (if closed
-		     (values (svref coord-seq (- len 2))
-			     (svref coord-seq (- len 1))
+		     (values (elt coord-seq (- len 2))
+			     (elt coord-seq (- len 1))
 			     x1 y1
 			     0 (- len 2))
 		     (values x1 y1
-			     (svref coord-seq (- len 2))
-			     (svref coord-seq (- len 1))
+			     (elt coord-seq (- len 2))
+			     (elt coord-seq (- len 1))
 			     2 (- len 4)))
 	       (ecase (line-style-joint-shape line-style)
 		 (:miter
@@ -1408,13 +1408,13 @@ were added."
 			for i from initial-index to final-index by 2
 			for xp = initial-xp then x
 			for yp = initial-yp then y
-			for x = (svref coord-seq i)
-			for y = (svref coord-seq (1+ i))
+			for x = (elt coord-seq i)
+			for y = (elt coord-seq (1+ i))
 			do (setf (values xn yn)
 				 (if (eql i final-index)
 				     (values final-xn final-yn)
-				     (values (svref coord-seq (+ i 2))
-					     (svref coord-seq (+ i 3)))))
+				     (values (elt coord-seq (+ i 2))
+					     (elt coord-seq (+ i 3)))))
 			   (multiple-value-bind (ex1 ey1)
 			       (normalize-coords (- x xp) (- y yp))
 			     (multiple-value-bind (ex2 ey2)
@@ -1444,13 +1444,13 @@ were added."
 			for i from initial-index to final-index by 2
 			for xp = initial-xp then x
 			for yp = initial-yp then y
-			for x = (svref coord-seq i)
-			for y = (svref coord-seq (1+ i))
+			for x = (elt coord-seq i)
+			for y = (elt coord-seq (1+ i))
 			do (setf (values xn yn)
 				 (if (eql i final-index)
 				     (values final-xn final-yn)
-				     (values (svref coord-seq (+ i 2))
-					     (svref coord-seq (+ i
+				     (values (elt coord-seq (+ i 2))
+					     (elt coord-seq (+ i
 								 3)))))
 			   (multiple-value-bind (ex1 ey1)
 			       (normalize-coords (- x xp) (- y yp))
@@ -1464,8 +1464,8 @@ were added."
 				 (maxf max-y (+ y ny))))))))
 	       (unless closed
 		 (multiple-value-bind (x y)
-		     (values (svref coord-seq (- len 2))
-			     (svref coord-seq (- len 1)))
+		     (values (elt coord-seq (- len 2))
+			     (elt coord-seq (- len 1)))
 		   (minf min-x (- x border))
 		   (minf min-y (- y border))
 		   (maxf max-x (+ x border))

--- a/Core/clim-basic/recording.lisp
+++ b/Core/clim-basic/recording.lisp
@@ -1216,18 +1216,16 @@ were added."
     `(with-sheet-medium (medium stream)
                   (when (stream-recording-p stream)
                     (let ((record
-                           ;; Hack: the coord-seq-mixin makes the
-                           ;; assumption that, well coord-seq is a
-                           ;; coord-vector. So we morph a possible
-                           ;; coord-seq argument into a vector.
+                           ;; initialize the output record with a copy
+                           ;; of coord-seq, as the replaying code will
+                           ;; modify it to be positioned relative to
+                           ;; the output-record's position and making
+                           ;; a temporary is (arguably) less bad than
+                           ;; untrasnforming the coords back to how
+                           ;; they were.
                            (let (,@(when (member 'coord-seq args)
-                                         `((coord-seq
-                                            (if (vectorp coord-seq)
-                                                coord-seq
-                                                (coerce coord-seq 'vector))))))
-                             (make-instance ',class-name
-                                            :stream stream
-                                            ,@arg-list))))
+                                     `((coord-seq (copy-seq coord-seq)))))
+                             (make-instance ',class-name :stream stream ,@arg-list))))
                       (stream-add-output-record stream record)))
                   (when (stream-drawing-p stream)
                     (,method-name medium ,@args)))))

--- a/Core/clim-basic/recording.lisp
+++ b/Core/clim-basic/recording.lisp
@@ -1518,27 +1518,27 @@ were added."
                               t
 			      filled))))
 
-(def-grecording draw-rectangles ((gs-line-style-mixin)
-                                 position-seq filled) (:medium-fn nil)
+(def-grecording draw-rectangles ((coord-seq-mixin gs-line-style-mixin)
+                                 coord-seq filled) (:medium-fn nil)
   (let* ((transform (medium-transformation medium))
          (border (graphics-state-line-style-border graphic medium)))
-    (let ((transformed-position-seq
+    (let ((transformed-coord-seq
            (map-repeated-sequence 'vector 2
                                   (lambda (x y)
                                     (with-transformed-position (transform x y)
                                       (values x y)))
-                                  position-seq)))
-      (polygon-record-bounding-rectangle transformed-position-seq
+                                  coord-seq)))
+      (polygon-record-bounding-rectangle transformed-coord-seq
                                          t filled line-style border
                                          (medium-miter-limit medium)))))
 
-(defmethod medium-draw-rectangles* :around ((stream output-recording-stream) position-seq filled)
+(defmethod medium-draw-rectangles* :around ((stream output-recording-stream) coord-seq filled)
   (let ((tr (medium-transformation stream)))
     (if (rectilinear-transformation-p tr)
         (generate-medium-recording-body draw-rectangles-output-record
 					medium-draw-rectangles*
-                                        (position-seq filled))
-	(do-sequence ((left top right bottom) position-seq)
+                                        (coord-seq filled))
+	(do-sequence ((left top right bottom) coord-seq)
           (medium-draw-polygon* stream (vector left top
                                                left bottom
                                                right bottom

--- a/Extensions/bezier/bezier.lisp
+++ b/Extensions/bezier/bezier.lisp
@@ -119,12 +119,13 @@
                                          &optional region x-offset y-offset)
   (declare (ignore x-offset y-offset region))
   (with-slots (design output-record-translation) record
-    (setf design (if output-record-translation
-                     (transform-region output-record-translation design)
-                     design))
-    (prog1
-        (call-next-method)
-      (setf output-record-translation nil))))
+    (let ((old-design design))
+      (setf design (if output-record-translation
+                       (transform-region output-record-translation design)
+                       design))
+      (prog1
+          (call-next-method)
+        (setf design old-design)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/Extensions/bezier/bezier.lisp
+++ b/Extensions/bezier/bezier.lisp
@@ -120,11 +120,12 @@
   (declare (ignore x-offset y-offset region))
   (with-slots (design output-record-translation) record
     (let ((old-design design))
-      (setf design (if output-record-translation
-                       (transform-region output-record-translation design)
-                       design))
-      (prog1
-          (call-next-method)
+      (unwind-protect
+           (progn
+             (setf design (if output-record-translation
+                              (transform-region output-record-translation design)
+                              design))
+             (call-next-method))
         (setf design old-design)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
These changes make it so that the output-recording coord-seq can be a seq, not just a vector, and fix a bunch of bugs encountered along the way. Previously, the functions under the covers only worked with vectors, but the drawing code for draw-lines, draw-points, draw-polygon, etc... only worked if we passed in a list which was copied to a vector. Now we can pass in either a list or a vector and the code under the covers should work with both lists and vectors. We still copy the sequence, as the copy gets transformed during the playback of the output record, but things are much less broken.

draw-rectangles, OTOH, was completely broken in multiple ways. It, too, is fixed, using the coord-seq-mixin infrastructure.

In general, all this output-recording/drawing code is a big hacky mess, but it's slightly less broken now.