### PR TITLE
Fix caps lock affecting non-alphabetic keys

### DIFF
--- a/Backends/CLX/keysyms-common.lisp
+++ b/Backends/CLX/keysyms-common.lisp
@@ -89,12 +89,12 @@
 ;;; reflect the post event state.
 
 (defun x-keysym-to-clim-modifiers (port event-key keychar keysym-name state)
-  "event-key is :key-press or :key-release"
-  (multiple-value-bind (clim-modifiers shift-lock? caps-lock? mode-switch?)
+  "Return modifiers for PORT with STATE. If KEYCHAR is a special key(like shift, caps-lock, etc.), update the modifiers cache. EVENT-KEY is :key-press or :key-release"
+  (multiple-value-bind (clim-modifiers caps-lock? mode-switch?)
       (x-event-state-modifiers port state)
-    (declare (ignore shift-lock? caps-lock? mode-switch?))
+    (declare (ignore caps-lock? mode-switch?))
     (if (characterp keychar)
-	clim-modifiers	;; ?? true?
+	clim-modifiers
 	(modify-modifiers event-key keysym-name clim-modifiers))))
 
 ;;; Modifier cache
@@ -115,10 +115,8 @@
 
 ;;; Definition of constants for the backend-specific modifier mask.
 (eval-when (:compile-toplevel :load-toplevel :execute)
-(defconstant +shift-lock+ 1)
-(defconstant +caps-lock+ 2)
-(defconstant +mode-switch+ 4)
-)
+  (defconstant +caps-lock+ 1)
+  (defconstant +mode-switch+ 4))
 
 ;;; This dictionary maps CLX keysym names to the power-of-two
 ;;; constants that the CLIM II specification requires.
@@ -134,8 +132,7 @@
 ;;; that we need anyway, in order to determine what keysym to choose
 ;;; based on current modifiers.
 (defconstant +other-modifiers+
-  '((:shift-lock #.+shift-lock+)
-    (:caps-lock #.+caps-lock+)
+  '((:caps-lock #.+caps-lock+)
     (:mode-switch #.+mode-switch+)))
 
 ;;; We need a way to interpret the individual bits of an X11 modifier
@@ -225,22 +222,13 @@
   (find :caps-lock (nth-value 1 (xlib:modifier-mapping display))
 	:key (lambda (keycode) (code-to-name keycode display))))
 
-;;; Return true if and only if the lock modifier should be interpreted
-;;; as SHIFT-LOCK.
-(defun lock-is-shift-lock-p (display)
-  (and (not (lock-is-caps-lock-p display))
-       (find :shift-lock (nth-value 1 (xlib:modifier-mapping display))
-	     :key (lambda (keycode) (code-to-name keycode display)))))
-
 ;;; Given an X11/CLX modifier mask, return a backend-specific modifier
 ;;; mask with the relevant bits set.
 (defun create-other-modifier-mask (clx-modifier-mask
 				   caps-lock-mask
-				   shift-lock-mask
 				   mode-switch-mask)
   (let ((m clx-modifier-mask))
     (logior (if (plusp (logand m caps-lock-mask)) +caps-lock+ 0)
-	    (if (plusp (logand m shift-lock-mask)) +shift-lock+ 0)
 	    (if (plusp (logand m mode-switch-mask)) +mode-switch+ 0))))
 
 ;;; Recall that the function MODIFIER-MAPPING is similar to the one
@@ -293,8 +281,7 @@
 (defun make-modifier-cache (port)
   (let* ((cache (make-array 256))
 	 (display (clim-clx::clx-port-display port))
-	 (caps-lock-mask (if (lock-is-caps-lock-p display) #b00 #b10))
-	 (shift-lock-mask (if (lock-is-shift-lock-p display) #b00 #b10))
+	 (caps-lock-mask (if (lock-is-caps-lock-p display) +lock-bit+ #b00))
 	 (mode-switch-position (mode-switch-position display))
 	 (mode-switch-mask (position-to-mask mode-switch-position)))
     (loop for x-modifier-mask from 0 below 256
@@ -302,9 +289,8 @@
 		   (cons (create-clim-modifier-mask x-modifier-mask)
 			 (create-other-modifier-mask x-modifier-mask
 						     caps-lock-mask
-						     shift-lock-mask
 						     mode-switch-mask))))
-    (setf (modifier-cache port) cache)))
+    cache))
 
 (defgeneric x-event-state-modifiers (port state)
   (:documentation "For the X STATE, returns as multiple values, the
@@ -321,7 +307,6 @@
 	(aref modifier-cache
 	      (mod state (length modifier-cache)))
       (values clim-modifiers
-	      (logtest +shift-lock+ other-modifiers)
 	      (logtest +caps-lock+ other-modifiers)
 	      (logtest +mode-switch+ other-modifiers)))))
 

--- a/Backends/CLX/keysyms-common.lisp
+++ b/Backends/CLX/keysyms-common.lisp
@@ -18,8 +18,8 @@
 ;;; Library General Public License for more details.
 ;;;
 ;;; You should have received a copy of the GNU Library General Public
-;;; License along with this library; if not, write to the 
-;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330, 
+;;; License along with this library; if not, write to the
+;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 ;;; Boston, MA  02111-1307  USA.
 
 ;;; Support and port mixin for X based backends, handling keycode to

--- a/Backends/CLX/keysyms.lisp
+++ b/Backends/CLX/keysyms.lisp
@@ -18,8 +18,8 @@
 ;;; Library General Public License for more details.
 ;;;
 ;;; You should have received a copy of the GNU Library General Public
-;;; License along with this library; if not, write to the 
-;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330, 
+;;; License along with this library; if not, write to the
+;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 ;;; Boston, MA  02111-1307  USA.
 
 (in-package :clim-clx)
@@ -91,14 +91,14 @@
   (multiple-value-bind (clim-modifiers shift-lock? caps-lock? mode-switch?)
       (clim-xcommon:x-event-state-modifiers port state)
     (let* ((display (clx-port-display port))
-	   (shift? (logtest +shift-key+ clim-modifiers))
+           (shift? (logtest +shift-key+ clim-modifiers))
            (shift-modifier? (if shift-lock?
                                 (not shift?)
                                 (if caps-lock? t shift?)))
-	   (shifted-keysym (xlib:keycode->keysym display keycode 
+           (shifted-keysym (xlib:keycode->keysym display keycode
                                                  (+ 1 (if mode-switch?
                                                           2 0))))
-           (unshifted-keysym (xlib:keycode->keysym display keycode 
+           (unshifted-keysym (xlib:keycode->keysym display keycode
                                                    (if mode-switch?
                                                        2 0)))
            (keysym (if shift-modifier?
@@ -112,16 +112,16 @@
                                                   2 0))))
              (modifiers (clim-xcommon:x-keysym-to-clim-modifiers
                          port
-			 event-key
-			 char
-			 (clim-xcommon:keysym-to-keysym-name keysym)
+                         event-key
+                         char
+                         (clim-xcommon:keysym-to-keysym-name keysym)
                          state)))
         (values char
-		;; We filter away the shift state if there is a
-		;; difference between the shifted and unshifted
-		;; keysym. This is so eg. #\A will not look like "#\A
-		;; with a Shift modifier", as this makes gesture
-		;; processing more difficult.
+                ;; We filter away the shift state if there is a
+                ;; difference between the shifted and unshifted
+                ;; keysym. This is so eg. #\A will not look like "#\A
+                ;; with a Shift modifier", as this makes gesture
+                ;; processing more difficult.
                 (if (= shifted-keysym unshifted-keysym)
                     modifiers
                     (logandc2 modifiers +shift-key+))
@@ -135,4 +135,3 @@
 
 (defun keysym-to-character (keysym)
   (numeric-keysym-to-character (clim-xcommon:keysym-name-to-keysym keysym)))
-


### PR DESCRIPTION
This is the fix to the issue #175 

The problem with caps lock was that 
(a) it was not recognized when caps-lock key was pressed (instead, the shift-lock was recognized)
(b) it did not handle the casing properly

I have tested this fix on my machine. I have changed the right shift with "Shift_Lock" modifier (instructions can be found here: http://xahlee.info/linux/linux_shift_lock_key.html )

When pressing the caps-lock, it is recognized and applied to the keysym.
When pressing shift, it is recognized and applied to the keysym.
When pressing both, they are recognized and applied correctly.

I have also removed shift-lock from the files I have edited. The reason for that is the way the shift-lock works; rather than triggering shift-lock key, it actually works as if the user was holding the shift all the time. This leaves shift-lock modifier without purpose.

Side note: I have found mentions of shift-lock in Backends/CLX/standard-keysym-rules , but I don't really know how the file is used. Should I somehow try to remove the shift-lock from there, too?  