### PR TITLE
Text editor pane value changed callback fix (with bonus spelling fixes)

### DIFF
--- a/Core/clim/text-editor-gadget.lisp
+++ b/Core/clim/text-editor-gadget.lisp
@@ -173,8 +173,8 @@ editor substrates."))
 (defclass text-field-pane (text-field
                            vrack-pane editor-substrate-user-mixin)
   ((activation-gestures :accessor activation-gestures
-			:initarg :activation-gestures
-			:documentation "A list of gestures that
+                        :initarg :activation-gestures
+                        :documentation "A list of gestures that
 cause the activate callback to be called."))
   (:default-initargs
    :activation-gestures *standard-activation-gestures*))
@@ -183,8 +183,8 @@ cause the activate callback to be called."))
                                        &key id client armed-callback
                                        disarmed-callback
                                        activation-gestures activate-callback
-					 value value-changed-callback
-					 (editable-p t))
+                                         value value-changed-callback
+                                         (editable-p t))
   ;; Make an editor substrate object for the gadget.
   (let ((pane (make-pane 'drei-text-field-substrate
                          :user-gadget object
@@ -214,11 +214,11 @@ cause the activate callback to be called."))
 (defmethod initialize-instance :after ((object text-editor-pane)
                                        &key id client armed-callback
                                          disarmed-callback
-					 activation-gestures activate-callback
-					 scroll-bars
-					 ncolumns nlines
-					 value value-changed-callback
-					 (editable-p t))
+                                         activation-gestures activate-callback
+                                         scroll-bars
+                                         ncolumns nlines
+                                         value value-changed-callback
+                                         (editable-p t))
   ;; Make an editor substrate object for the gadget.
   (let* ((minibuffer (when scroll-bars
                        (make-pane 'drei::drei-minibuffer-pane)))
@@ -254,4 +254,3 @@ cause the activate callback to be called."))
     (setf (gadget-value substrate) value
           (substrate object) substrate)
     (sheet-adopt-child object sheet)))
-

--- a/Libraries/Drei/drei-clim.lisp
+++ b/Libraries/Drei/drei-clim.lisp
@@ -214,20 +214,21 @@ command loop completely."))
 
 ;;; The fun is that in the gadget version of Drei, we do not control
 ;;; the application command loop, and in fact, need to operate
-;;; completely independently of it - we can only act when the our port
+;;; completely independently of it - we can only act when our port
 ;;; deigns to bestow an event upon the gadget. So, we basically have
 ;;; to manually take care of reading gestures (asynchronously),
-;;; redisplaying, updating the syntax and all the other fun
-;;; details. On top of this, we have to account for the fact that some
-;;; other part of the application might catch the users fancy, and
-;;; since we do not (and can not) control the command loop, we can not
-;;; prevent the user from "leaving" the gadget at inconvenient times
-;;; (such as in the middle of entering a complex set of gestures, or
-;;; answering questions asked by a command). So, we keep some state
-;;; information in the `drei-gadget-pane' object and use it to cobble
-;;; together our own poor man's version of an ESA command loop. Syntax
-;;; updating is done after a command has been executed, and only then
-;;; (or by commands at their own discretion).
+;;; redisplaying, updating the syntax and all the other fun details.
+;;;
+;;; On top of this, we have to account for the fact that some other
+;;; part of the application might catch the user's fancy, and since we
+;;; do not (and can not) control the command loop, we can not prevent
+;;; the user from "leaving" the gadget at inconvenient times (such as
+;;; in the middle of entering a complex set of gestures, or answering
+;;; questions asked by a command). So, we keep some state information
+;;; in the `drei-gadget-pane' object and use it to cobble together our
+;;; own poor man's version of an ESA command loop. Syntax updating is
+;;; done after a command has been executed, and only then (or by
+;;; commands at their own discretion).
 (defclass drei-gadget-pane (drei-pane value-gadget action-gadget
                                       asynchronous-command-processor
                                       dead-key-merging-command-processor)
@@ -329,12 +330,12 @@ modifier key."))
   ;; Cargo-culted from above:
   (unless (and (currently-processing-p gadget) (directly-processing-p gadget))
     (letf (((currently-processing-p gadget) t))
-      (insert-sequence (point (view gadget)) 
+      (insert-sequence (point (view gadget))
                        (clim-backend:get-selection-from-event (port gadget) event))
       (display-drei gadget :redisplay-minibuffer t)
       (propagate-changed-value gadget))))
 
-(defmethod handle-event :before 
+(defmethod handle-event :before
     ((gadget drei-gadget-pane) (event pointer-button-press-event))
   (let ((previous (stream-set-input-focus gadget)))
     (when (and previous (typep previous 'gadget))

--- a/Libraries/Drei/syntax.lisp
+++ b/Libraries/Drei/syntax.lisp
@@ -76,16 +76,18 @@ made to execute an operation that is unavailable for the particular syntax" ))
 (defgeneric update-syntax (syntax unchanged-prefix unchanged-suffix
                                   &optional begin end)
   (:documentation "Inform the syntax module that it must update
-its view of the buffer. `Unchanged-prefix' `unchanged-suffix'
-indicate what parts of the buffer has not been changed. `Begin'
-and `end' are offsets specifying the minimum region of the buffer
-that must have an up-to-date parse, defaulting to 0 and the size
-of the buffer respectively. It is perfectly valid for a syntax to
-ignore these hints and just make sure the entire syntax tree is
-up to date, but it *must* make sure at at least the region
-delimited by `begin' and `end' has an up to date parse. Returns
-two values, offsets into the buffer of the syntax, denoting the
-buffer region thas has an up to date parse.")
+its view of the buffer. `Unchanged-prefix' and `unchanged-suffix'
+indicate what parts of the buffer have not been changed.
+
+`Begin' and `end' are offsets specifying the minimum region of the
+buffer that must have an up-to-date parse, defaulting to 0 and the
+size of the buffer respectively. It is perfectly valid for a syntax to
+ignore these hints and just make sure the entire syntax tree is up to
+date, but it *must* make sure at least the region delimited by `begin'
+and `end' has an up to date parse.
+
+Returns two values, offsets into the buffer of the syntax, denoting
+the buffer region that has an up-to-date parse.")
   (:method-combination values-max-min :most-specific-last))
 
 (defgeneric eval-defun (mark syntax))
@@ -155,11 +157,11 @@ specified in the usual way with :inherit-from."
 ;;; Commenting
 
 (defgeneric syntax-line-comment-string (syntax)
-  (:documentation "string to use at the beginning of a line to 
+  (:documentation "string to use at the beginning of a line to
 indicate a line comment"))
 
 (defgeneric line-comment-region (syntax mark1 mark2)
-  (:documentation "inset a line comment string at the beginning of 
+  (:documentation "inset a line comment string at the beginning of
 every line in the region"))
 
 (defmethod line-comment-region (syntax mark1 mark2)
@@ -174,10 +176,10 @@ every line in the region"))
 	  do (insert-sequence mark (syntax-line-comment-string syntax))
 	     (end-of-line mark)
 	     (unless (end-of-buffer-p mark)
-	       (forward-object mark)))))	  
+	       (forward-object mark)))))
 
 (defgeneric line-uncomment-region (syntax mark1 mark2)
-  (:documentation "inset a line comment string at the beginning of 
+  (:documentation "inset a line comment string at the beginning of
 every line in the region"))
 
 (defmethod line-uncomment-region (syntax mark1 mark2)
@@ -499,7 +501,7 @@ incrementally."))
   (insert* (lexemes lexer) pos lexeme))
 
 (defmethod delete-invalid-lexemes ((lexer incremental-lexer) from to)
-  "delete all lexemes between FROM and TO and return the first invalid 
+  "delete all lexemes between FROM and TO and return the first invalid
 position in the lexemes of LEXER"
   (with-slots (lexemes) lexer
      (let ((start 1)
@@ -515,7 +517,7 @@ position in the lexemes of LEXER"
 		       (mark> (start-mark (element* lexemes start)) to))
 	     do (delete* lexemes start))
        start)))
-	       
+
 (defmethod skip-inter-lexeme-objects ((lexer incremental-lexer) scan)
   (loop until (end-of-buffer-p scan)
 	while (inter-lexeme-object-p lexer (object-after scan))
@@ -594,7 +596,7 @@ position in the lexemes of LEXER"
   (let ((rule (gensym "RULE"))
 	(rules (gensym "RULES"))
 	(result (gensym "RESULT")))
-    `(let* ((,rules (list ,@(loop for rule in body 
+    `(let* ((,rules (list ,@(loop for rule in body
 				  collect `(grammar-rule ,rule))))
 	    (,result (make-instance 'grammar)))
        (dolist (,rule ,rules ,result)
@@ -644,7 +646,7 @@ position in the lexemes of LEXER"
   (format stream " *")
   (loop for i from (dot-position item) below (length (symbols (rule item)))
 	do (format stream " ~a" (aref (symbols (rule item)) i)))
-  (format stream "]"))	  
+  (format stream "]"))
 
 (defun derive-and-handle-item (prev-item parse-tree orig-state to-state)
   (let ((remaining (funcall (suffix prev-item) parse-tree)))
@@ -759,18 +761,18 @@ position in the lexemes of LEXER"
 (defun handle-incomplete-item (item orig-state to-state)
   (declare (optimize speed))
   (cond ((find item (the list (gethash orig-state (incomplete-items to-state)))
- 	       :test #'item-equal)
+               :test #'item-equal)
 	  nil)
- 	(t
- 	 (push item (gethash orig-state (incomplete-items to-state))))))
+        (t
+         (push item (gethash orig-state (incomplete-items to-state))))))
 
 (defun handle-and-predict-incomplete-item (item state tokens)
   (declare (optimize speed))
   (cond ((find item (the list (gethash state (incomplete-items state)))
- 	       :test #'item-equal)
+               :test #'item-equal)
 	  nil)
- 	(t
- 	 (push item (gethash state (incomplete-items state)))
+        (t
+         (push item (gethash state (incomplete-items state)))
 	 (predict item state tokens))))
 
 (defmethod initialize-instance :after ((parser parser) &rest args)
@@ -814,7 +816,7 @@ position in the lexemes of LEXER"
 	       (predict item state tokens)))
 	   (incomplete-items state))
   (let ((new-state (make-instance 'parser-state :parser parser)))
-    (loop for token in tokens 
+    (loop for token in tokens
 	  do (potentially-handle-parse-tree token state new-state))
     (setf (last-nonempty-state new-state)
 	  (if (or (plusp (hash-table-count (incomplete-items new-state)))
@@ -857,7 +859,7 @@ represent a complete parse of the target."
 
 (defun parse-stack-parse-trees (parse-stack)
   "given a parse stack frame, return a list (in the reverse order of
-analysis) of the parse trees recognized.  The return value reveals 
+analysis) of the parse trees recognized.  The return value reveals
 internal state of the parser.  Do not alter it!"
   (assert (not (null parse-stack)))
   (parse-trees parse-stack))


### PR DESCRIPTION
The way this was implemented previously, namely passing the value of the ``value-changed-callback`` _initarg_ to the substrate object, bypassed the ``value-changed-callback`` _method_ of the ``text-editor-pane`` instance, violating the description of ``value-changed-callback`` in [30.3 (Basic Gadget Classes)](http://bauhh.dyndns.org:8000/clim-spec/30-3.html#_6734).

With this change a value-changed callback is installed in the substrate object that invokes the ``value-changed-callback`` method for the ``text-editor-pane``.

Another (potential) benefit of this change is that the ``id`` and ``client`` initargs can be handled by the ``text-editor-pane`` instance normally instead of being passed to the substrate object. This seems more
accurate and more robust (e.g. in case the id and/or client were to change in the ``text-editor-pane`` instance for some reason, the new values would be "picked up").
