### PR TITLE
Use Alexandria-provided macros and functions

### DIFF
--- a/Apps/Listener/dev-commands.lisp
+++ b/Apps/Listener/dev-commands.lisp
@@ -88,8 +88,9 @@
 	(lambda-list (clim-mop:method-lambda-list object))
 	(class-of-t (find-class t)))
     (format stream "~S ~{~S ~}(" name qualifiers)
-    (multiple-value-bind (required optional rest key key-present)
-	(climi::parse-lambda-list lambda-list)
+    (multiple-value-bind (required optional rest key allow-other-keys aux key-present)
+        (alexandria:parse-ordinary-lambda-list lambda-list)
+      (declare (ignore allow-other-keys aux))
       (loop
 	 for spec in specializers
 	 for arg in required
@@ -838,7 +839,7 @@ if you are interested in fixing this."))
 	  (return-from make-gf-specialized-ptype nil))))
     (unless (typep gf 'generic-function)
       (return-from make-gf-specialized-ptype nil))
-    (let ((required (climi::parse-lambda-list
+    (let ((required (alexandria:parse-ordinary-lambda-list
 		     (clim-mop::generic-function-lambda-list gf))))
       (loop
 	 for arg in required

--- a/Core/clim-basic/utils.lisp
+++ b/Core/clim-basic/utils.lisp
@@ -280,10 +280,6 @@ by the number of variables in VARS."
 		 (declare (ignorable ,vars))
 		 ,result-form)))))))
 
-(defun clamp (value min max)
-  "Clamps the value 'value' into the range [min,max]."
-  (max min (min max value)))
-  
 ;;;;
 ;;;; meta functions
 ;;;;
@@ -328,14 +324,6 @@ by the number of variables in VARS."
 	,@body)
     (find-command-table ,command-table)))
 
-;;;
-
-(defmacro with-gensyms (syms &body body)
-  "Binds each symbol in the list `syms' to a gensym which uses the
-  name of the symbol."
-  `(let ,(mapcar (lambda (symbol) `(,symbol (gensym ,(symbol-name symbol))))
-                 syms)
-     ,@ body))
 
 (defun parse-method (description)
   (loop
@@ -545,30 +533,6 @@ STREAM in the direction DIRECTION."
 		(values (cdr tail) t)))
      finally (return (values list nil))))
 
-;;; Why do I feel like I've written this function 8 million times
-;;; already?
-
-(defun parse-lambda-list (ll)
-  "Extract the parts of a function or method lambda list.
-
-  Returns values of required, &optional, &rest and &key
-  parameters. 5th value indicates that &key was seen"
-  (loop
-       with state = 'required
-       for var in ll
-       if (member var '(&optional &rest &key))
-        do (setq state var)
-       else if (eq state 'required)
-         collect var into required
-       else if (eq state '&optional)
-         collect var into optional
-       else if (eq state '&rest)
-         collect var into rest
-       else if (eq state '&key)
-         collect var into key
-       end
-       finally (return (values required optional rest key (eq state '&key)))))
-
 (defun rebind-arguments (arg-list)
   "Create temporary variables for non keywords in a list of
   arguments. Returns two values: a binding list for let, and a new
@@ -583,16 +547,6 @@ STREAM in the direction DIRECTION."
        and collect var into new-arg-list
      end
      finally (return (values bindings new-arg-list))))
-
-(defun make-keyword (obj)
-  "Turn OBJ into a keyword"
-  (etypecase obj
-    (keyword
-     obj)
-    (symbol
-     (intern (symbol-name obj) :keyword))
-    (string
-     (intern (string-upcase obj) :keyword))))
 
 ;;; Command name utilities that are useful elsewhere.
 

--- a/Core/clim-core/commands.lisp
+++ b/Core/clim-core/commands.lisp
@@ -1149,9 +1149,9 @@ examine the type of the command menu item to see if it is
       name-and-options
     (with-keywords-removed (options (:provide-output-destination-keyword))
       (if provide-output-destination-keyword
-	  (multiple-value-bind (required optional rest key key-supplied)
-	      (parse-lambda-list args)
-	    (declare (ignore required optional rest key))
+	  (multiple-value-bind (required optional rest key allow-other-keys aux key-supplied)
+	      (alexandria:parse-ordinary-lambda-list args)
+	    (declare (ignore required optional rest key allow-other-keys aux))
 	    (let* ((destination-arg '(output-destination 'output-destination
 				      :default nil))
 		   (new-args (if key-supplied

--- a/Libraries/ESA/esa-mcclim.asd
+++ b/Libraries/ESA/esa-mcclim.asd
@@ -6,7 +6,7 @@
 ;;; ASDF system definition for ESA.
 
 (defsystem #:esa-mcclim
-  :depends-on (#:clim-core)
+  :depends-on (#:clim-core #:alexandria)
   :components ((:file "packages")
                (:file "utils" :depends-on ("packages"))
                (:file "esa" :depends-on ("packages" "utils"))

--- a/Libraries/ESA/packages.lisp
+++ b/Libraries/ESA/packages.lisp
@@ -27,8 +27,7 @@
   (:shadowing-import-from :clim-lisp #:describe-object)
   (:import-from #:alexandria
 		#:once-only
-		#:with-gensyms
-		)
+		#:with-gensyms)
   (:export #:with-gensyms
 	   #:once-only
            #:unlisted

--- a/Libraries/ESA/packages.lisp
+++ b/Libraries/ESA/packages.lisp
@@ -25,8 +25,12 @@
 (defpackage :esa-utils
   (:use :clim-lisp :clim-mop :clim)
   (:shadowing-import-from :clim-lisp #:describe-object)
+  (:import-from #:alexandria
+		#:once-only
+		#:with-gensyms
+		)
   (:export #:with-gensyms
-           #:once-only
+	   #:once-only
            #:unlisted
            #:fully-unlisted
            #:listed

--- a/Libraries/ESA/utils.lisp
+++ b/Libraries/ESA/utils.lisp
@@ -11,19 +11,6 @@
 
 (in-package :esa-utils)
 
-;;; Cribbed from Paul Graham
-(defmacro with-gensyms (syms &body body)
-  `(let ,(mapcar #'(lambda (s) `(,s (gensym))) syms)
-     ,@body))
-
-;;; Cribbed from PCL by Seibel
-(defmacro once-only ((&rest names) &body body)
-  (let ((gensyms (loop for n in names collect (gensym))))
-    `(let (,@(loop for g in gensyms collect `(,g (gensym))))
-       `(let (,,@(loop for g in gensyms for n in names collect ``(,,g ,,n)))
-          ,(let (,@(loop for n in names for g in gensyms collect `(,n ,g)))
-                ,@body)))))
-
 (defun unlisted (obj &optional (fn #'first))
   (if (listp obj)
       (funcall fn obj)

--- a/package.lisp
+++ b/package.lisp
@@ -2045,7 +2045,10 @@
   #+excl
   (:import-from :excl compile-system load-system)
   (:import-from #:alexandria
-                #:ensure-gethash)
+                #:clamp
+                #:make-keyword
+                #:ensure-gethash
+		#:with-gensyms)
   (:intern #:letf))
 
 (defpackage :clim-user


### PR DESCRIPTION
* PARSE-ORDINARY-LAMBDA-LIST
* MAKE-KEYWORD
  McCLIM's own implementation used to be a no-op if the argument was a
  keyword.  However, CL:INTERN handles keywords gracefully.
* ONCE-ONLY
* WITH-GENSYMS
* CLAMP