### PR TITLE
Pdf backend improvements

### DIFF
--- a/Backends/PDF/class.lisp
+++ b/Backends/PDF/class.lisp
@@ -67,10 +67,11 @@
   ((file-stream :initarg :file-stream :reader clim-pdf-stream-file-stream)
    (title :initarg :title)
    (for :initarg :for)
-   (orientation :initarg :orientation)
+   (orientation :initarg :orientation :accessor orientation)
    (paper :initarg :paper)
    (transformation :initarg :transformation
-                   :reader sheet-native-transformation)
+                   :initform nil
+                   :accessor sheet-native-transformation)
    (current-page :initform 0)
    (document-fonts :initform '())
    (graphics-state-stack :initform '())

--- a/Backends/PDF/class.lisp
+++ b/Backends/PDF/class.lisp
@@ -86,8 +86,11 @@
                    *default-pdf-title*))
         (for (or (getf header-comments :for)
                  *default-pdf-for*))
-        (region (paper-region device-type orientation))
-        (transform (make-pdf-transformation device-type orientation)))
+        (region (etypecase device-type
+                  (keyword (paper-region device-type orientation))
+                  (list (destructuring-bind (width height)
+                            device-type
+                          (make-rectangle* 0 0 width height))))))
     (make-instance 'clim-pdf-stream
                    :file-stream file-stream
                    :port port
@@ -95,8 +98,7 @@
                    :orientation orientation
                    :paper device-type
                    :native-region region
-                   :region region
-                   :transformation transform)))
+                   :region region)))
 
 ;;;; Port
 

--- a/Backends/PDF/paper.lisp
+++ b/Backends/PDF/paper.lisp
@@ -31,28 +31,36 @@
 
 (defun paper-region (paper-size-name orientation)
   (multiple-value-bind (width height) (paper-size paper-size-name)
-    (when (eq orientation :landscape)
-      (rotatef width height))
     (make-rectangle* 0 0 width height)))
 
-(defparameter *pdf-top-margin* 1)
-(defparameter *pdf-left-margin* 1)
-(defparameter *pdf-bottom-margin* 1)
-(defparameter *pdf-right-margin* 1)
+(defparameter *pdf-top-margin* 0)
+(defparameter *pdf-left-margin* 0)
+(defparameter *pdf-bottom-margin* 0)
+(defparameter *pdf-right-margin* 0)
 
-(defun make-pdf-transformation (paper-size-name orientation)
-  (multiple-value-bind (width height) (paper-size paper-size-name)
-    (case orientation
-      (:portrait
+(defun make-pdf-transformation (region orientation)
+  (case orientation
+    (:portrait
+     (multiple-value-bind (left top right bottom)
+         (bounding-rectangle* region)
        (make-3-point-transformation*
-        0 0
-         0 (- height *pdf-top-margin* *pdf-bottom-margin*)
-          (- width *pdf-left-margin* *pdf-right-margin*) 0
-        *pdf-left-margin* (- height *pdf-top-margin*)
-         *pdf-left-margin* *pdf-bottom-margin*
-          (- width *pdf-right-margin*) (- height *pdf-top-margin*)))
-      (:landscape
+        left top
+        left bottom
+        right top
+
+        *pdf-left-margin* (- bottom *pdf-top-margin*)
+        *pdf-left-margin* *pdf-bottom-margin*
+        (- right *pdf-right-margin*) (- bottom *pdf-top-margin*))))
+
+    (:landscape
+     (multiple-value-bind (left top right bottom)
+         (bounding-rectangle* region)
        (make-3-point-transformation*
-        0 0  0 width  height 0
-        width height  0 height  width 0))
-      (t (error "Unknown orientation")))))
+        left top
+        left bottom
+        right top
+
+        *pdf-left-margin* (- right *pdf-top-margin*)
+        (- bottom *pdf-top-margin*) (- right *pdf-right-margin*)
+        *pdf-left-margin* *pdf-bottom-margin*)))
+    (t (error "Unknown orientation"))))


### PR DESCRIPTION
Various PDF enhancements. The big one (for me anyway) is that I can now make a PDF to a certain size, including just the size of the output.

 * add trim-page-to-output-size keyword argument to
   clim-pdf:with-output-to-pdf-stream

 * device-type can now be a list of the form (width height) to specify
   the page size, instead of being locked into the fix named paper
   sizes

 * landscape printing is better, but text prints rotated 90
   degrees (that is to say that it isn't rotated, as it should be).

 * add orientation accessor

 * make sheet-native-transformation be an acessor, not just a reader
