### PR TITLE
Prettier page header highlight in tab layout

### DIFF
--- a/Backends/CLX/medium.lisp
+++ b/Backends/CLX/medium.lisp
@@ -1,10 +1,10 @@
 ;;; -*- Mode: Lisp; Package: CLIM-CLX -*-
 
 ;;;  (c) copyright 1998,1999,2000,2001 by Michael McDonald (mikemac@mikemac.com)
-;;;  (c) copyright 2000 by 
+;;;  (c) copyright 2000 by
 ;;;           Iban Hatchondo (hatchond@emi.u-bordeaux.fr)
 ;;;           Julien Boninfante (boninfan@emi.u-bordeaux.fr)
-;;;  (c) copyright 2000, 2014 by 
+;;;  (c) copyright 2000, 2014 by
 ;;;           Robert Strandh (robert.strandh@gmail.com)
 ;;;  (c) copyright 2001 by Arnaud Rouanet (rouanet@emi.u-bordeaux.fr)
 ;;;  (c) copyright 1998,1999 by Gilbert Baumann
@@ -20,8 +20,8 @@
 ;;; Library General Public License for more details.
 ;;;
 ;;; You should have received a copy of the GNU Library General Public
-;;; License along with this library; if not, write to the 
-;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330, 
+;;; License along with this library; if not, write to the
+;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 ;;; Boston, MA  02111-1307  USA.
 
 (in-package :clim-clx)
@@ -213,7 +213,7 @@
 
 ;;; From Tagore Smith <tagore@tagoresmith.com>
 
-(defmethod medium-gcontext ((medium clx-medium) 
+(defmethod medium-gcontext ((medium clx-medium)
 			    (ink climi::standard-flipping-ink))
   (let* ((gc (medium-gcontext medium (medium-background medium)))
 	 (port (port medium))
@@ -334,7 +334,7 @@
                             (loop for i from 0 below num-bytes collect i)))))
 
 (defun generate-indexed-converter-expr (rgb-masks byte-order num-bytes)
-  `(lambda (image-array converted-data mask-data width height inks)  
+  `(lambda (image-array converted-data mask-data width height inks)
     (declare (optimize (speed 3)
                        (safety 0)
                        (space 0)
@@ -347,7 +347,7 @@
                         (mask-bitcursor 1))
                    (declare (type (unsigned-byte 9) mask-bitcursor)
                     (type xlib:array-index mask-index index))
-                   
+
                    (multiple-value-bind (red-map green-map blue-map opacity-map) (inks-to-rgb inks)
                      (dotimes (y height)
                        (unless (= 1 mask-bitcursor)
@@ -361,7 +361,7 @@
 					   mask-bitcursor)))
                            (let ((red   (elt red-map ink-index))
                                  (green (elt green-map ink-index))
-                                 (blue  (elt blue-map ink-index)))                             
+                                 (blue  (elt blue-map ink-index)))
                              ,',(generate-pixel-assignments 'converted-data 'index
                                                             (mapcar #'list '(red green blue) rgb-masks)
                                                             num-bytes byte-order))
@@ -392,10 +392,10 @@
                      (mask-bitcursor 1))
                  (declare (type (unsigned-byte 9) mask-bitcursor)
                           (type xlib:array-index mask-index))
-                 
+
                  (multiple-value-bind (red-map green-map blue-map opacity-map) (inks-to-rgb inks)
                    (declare (ignore red-map green-map blue-map))
-                   
+
                    (dotimes (y height)
                      (unless (= 1 mask-bitcursor)
                        (setf mask-bitcursor 1
@@ -430,15 +430,15 @@
                          (xlib:visual-info-blue-mask visual-info))))
     (ensure-indexed-converter rgb-masks byte-order bytes-per-pixel)))
 
-(defparameter *typical-pixel-formats* 
+(defparameter *typical-pixel-formats*
   '(((#xFF0000 #xFF00 #xFF) :LSBFIRST 4)
     ((#xFF0000 #xFF00 #xFF) :MSBFIRST 4))
   "This is a table of the most likely pixel formats. Converters for
-these should be compiled in advance. Compiling the indexed->rgba 
+these should be compiled in advance. Compiling the indexed->rgba
 converter in advance will eliminate the pause observable the first
 time an indexed pattern is drawn.")
 
-(dolist (format *typical-pixel-formats*)  
+(dolist (format *typical-pixel-formats*)
   (apply 'ensure-indexed-converter format))
 
 (defun fill-pixmap-indexed (visual-info depth byte-order array pm pm-gc mask mask-gc w h inks)
@@ -453,16 +453,16 @@ time an indexed pattern is drawn.")
                                 :element-type '(unsigned-byte 8)
                                 :initial-element #xff))
          (pixel-converter nil))
-         
+
     (if (and bytes-per-pixel
              (member byte-order '(:lsbfirst :msbfirst))
-             (setf pixel-converter (visual-get-indexed-converter 
+             (setf pixel-converter (visual-get-indexed-converter
                                     visual-info byte-order bytes-per-pixel)))
         ;; Fast path - Image upload
         (let ((converted-data (make-array (* bytes-per-pixel (array-total-size array)) :element-type 'xlib:card8)))
           ;; Fill the pixel arrays
           (funcall pixel-converter array converted-data mask-data w h inks)
-    
+
           ;; Create an xlib "image" and copy it to our pixmap.
           ;; I do this because I'm not smart enough to operate xlib:put-raw-image.
           (let ((image (xlib:create-image :bits-per-pixel (* 8 bytes-per-pixel) :depth depth
@@ -472,20 +472,20 @@ time an indexed pattern is drawn.")
             (xlib:put-image (pixmap-xmirror pm) pm-gc image
                             :x 0 :y 0
                             :width w :height h)))
-        
+
         ;; Fallback for unsupported visual, plotting pixels
         (progn
           (dotimes (y h)
             (dotimes (x w)
               (let ((ink (elt inks (aref array y x))))
-                (unless (eq ink +transparent-ink+) 
+                (unless (eq ink +transparent-ink+)
                   (draw-point* pm x y :ink ink)))))
           (convert-indexed->mask array mask-data w h inks)))
 
     ;; We can use image upload for the mask in either case.
     (let ((mask-image (xlib:create-image :bits-per-pixel 1 :depth 1
                                          :bit-lsb-first-p t
-                                         :byte-lsb-first-p t                                          
+                                         :byte-lsb-first-p t
                                          :width w :height h
                                          :data mask-data)))
       (xlib:put-image mask mask-gc mask-image
@@ -522,7 +522,7 @@ time an indexed pattern is drawn.")
 
       (xlib:draw-rectangle mask mask-gc 0 0 w h t)
       (setf (xlib:gcontext-foreground mask-gc) 0)
-      
+
       (let ((gc (xlib:create-gcontext :drawable drawable)))
         (setf (xlib:gcontext-fill-style gc) :tiled
               (xlib:gcontext-tile gc) (port-lookup-mirror (port pm) pm)
@@ -535,13 +535,13 @@ time an indexed pattern is drawn.")
         (let ((byte-order (xlib:display-byte-order display))
               ;; Hmm. Pixmaps are not windows, so you can't query their visual.
               ;; We'd like to draw to pixmaps as well as windows, so use the
-              ;; depth and visual of the screen root, and hope this works.              
+              ;; depth and visual of the screen root, and hope this works.
               ;(visual-info (xlib:window-visual-info drawable))
               (visual-info (xlib:visual-info display (xlib:screen-root-visual screen)))
               (depth (xlib:screen-root-depth screen))
               (*print-base* 16))
           (fill-pixmap-indexed visual-info depth byte-order array pm pm-gc mask mask-gc w h inks))
-          
+
         (xlib:free-gcontext mask-gc)
         (xlib:free-gcontext pm-gc)
         gc))))
@@ -598,9 +598,9 @@ time an indexed pattern is drawn.")
 ;;; coming from and kill them at the source...
 #-nil
 (defun clipping-region->rect-seq (clipping-region)
-  (typecase clipping-region 
+  (typecase clipping-region
     (area (multiple-value-list (region->clipping-values clipping-region)))
-    (t (loop 
+    (t (loop
           for region in (nreverse (mapcan
                                    (lambda (v) (unless (eq v +nowhere+) (list v)))
                                    (region-set-regions clipping-region
@@ -677,7 +677,7 @@ time an indexed pattern is drawn.")
                              (to-drawable pixmap) to-x to-y)
   (xlib:copy-area (pixmap-xmirror from-drawable)
                   (medium-gcontext (sheet-medium (slot-value to-drawable 'sheet))
-                                   +background-ink+)              
+                                   +background-ink+)
                   (round-coordinate from-x) (round-coordinate from-y)
                   (round width) (round height)
                   (pixmap-xmirror to-drawable)
@@ -986,7 +986,7 @@ time an indexed pattern is drawn.")
           (setq char (char-code (char src i)))
           (if (or (< char min-char-index) (> char max-char-index))
               (progn
-                (warn "Character ~S not representable in font ~S" 
+                (warn "Character ~S not representable in font ~S"
                       (char src i) afont)
                 (return i))
               (setf (aref dst j) char)))
@@ -997,9 +997,9 @@ time an indexed pattern is drawn.")
 	     i)
           (declare (type xlib:array-index i j))
           (setq elt (elt src i))
-          (when (characterp elt) 
+          (when (characterp elt)
             (setq elt (char-code elt)))
-          (if (or (not (integerp elt)) 
+          (if (or (not (integerp elt))
                   (< elt min-char-index)
                   (> elt max-char-index))
               (progn
@@ -1184,7 +1184,7 @@ time an indexed pattern is drawn.")
 			       (max 0 (min #xffff (- max-x min-x)))
 			       (max 0 (min #xffff (- max-y min-y)))
 			       t))))))
-  
+
 (defmethod medium-beep ((medium clx-medium))
   (xlib:bell (clx-port-display (port medium))))
 
@@ -1208,4 +1208,3 @@ time an indexed pattern is drawn.")
 
 (defmethod climi::medium-invoke-with-possible-double-buffering (frame pane (medium clx-medium) continuation)
   (funcall continuation))
-

--- a/Examples/clim-examples.asd
+++ b/Examples/clim-examples.asd
@@ -1,7 +1,6 @@
-
 ;;; CLIM-Examples depends on having at least one backend loaded.
 (asdf:defsystem #:clim-examples
-    :depends-on (#:mcclim #:mcclim-layouts/tab :mcclim-raster-image #:mcclim-bezier)
+    :depends-on (#:mcclim #:mcclim-layouts/tab :mcclim-raster-image #:mcclim-bezier #:closer-mop)
     :components
     ((:file "package")
      (:file "calculator")

--- a/Examples/method-browser.lisp
+++ b/Examples/method-browser.lisp
@@ -78,7 +78,7 @@ specialized on, removing duplicates"
 ;; class specializer for which no prototype instance is available.
 (defun compute-applicable-methods-from-specializers (gf specializers)
   (if (every #'classp specializers)
-      (compute-applicable-methods-using-classes gf specializers)
+      (c2mop:compute-applicable-methods-using-classes gf specializers)
       (let ((instances
              (mapcar (lambda (s)
                        (cond ((classp s)

--- a/Examples/method-browser.lisp
+++ b/Examples/method-browser.lisp
@@ -15,8 +15,8 @@
 ;;; Library General Public License for more details.
 ;;;
 ;;; You should have received a copy of the GNU Library General Public
-;;; License along with this library; if not, write to the 
-;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330, 
+;;; License along with this library; if not, write to the
+;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 ;;; Boston, MA  02111-1307  USA.
 
 ;;; --------------------------------------------------------------------
@@ -81,7 +81,7 @@ specialized on, removing duplicates"
       (compute-applicable-methods-using-classes gf specializers)
       (let ((instances
              (mapcar (lambda (s)
-                       (cond ((classp s) 
+                       (cond ((classp s)
                               ;; Implementation-dependent whether prototypes for
                               ;; built-in classes (like integer, t) are available.
                               (multiple-value-bind (prot err)
@@ -148,7 +148,7 @@ specialized on, removing duplicates"
 
 (defun maybe-find-gf (name)
   "Search for the generic function named by the user"
-  (ignore-errors 
+  (ignore-errors
     (let ((sym (read-from-string name)))
       (and sym
            (fboundp sym)
@@ -203,7 +203,7 @@ specialized on, removing duplicates"
                    :background +white+
                    :text-style (make-text-style :sans-serif :roman :large))
    ;; Empty vertical layout pane where option-panes for arguments are added
-    (arg-pane :vrack-pane)    
+    (arg-pane :vrack-pane)
    ;; Blank pane where the program can render output
     (output-pane :application-pane
                  :text-style (make-text-style :sans-serif :roman :normal)
@@ -260,7 +260,7 @@ available for that argument."
     ;; option-panes for each specializer argument.
     (let ((fm (frame-manager *application-frame*)))
       (with-look-and-feel-realization (fm *application-frame*)
-        (sheet-adopt-child container            
+        (sheet-adopt-child container
           (make-pane 'table-pane :spacing 8    ;; McCLIM issue: spacing initarg
             :contents (loop for index from 0 by 1
                             for curval in arg-types
@@ -323,7 +323,7 @@ available for that argument."
            (methods (compute-applicable-methods-from-specializers gf (arg-types frame)))
            (combination (c2mop:generic-function-method-combination gf))
            (effective-methods (c2mop:compute-effective-method gf combination methods))
-           (serial-methods (walk-em-form effective-methods)))      
+           (serial-methods (walk-em-form effective-methods)))
       ;; Print the header
       (fresh-line)
       (with-drawing-options (pane :text-style (make-text-style :sans-serif :bold :large)

--- a/Examples/tabdemo.lisp
+++ b/Examples/tabdemo.lisp
@@ -25,10 +25,11 @@
    (default
        (vertically ()
 	 (with-tab-layout ('tab-page :name 'tabdemo-layout :height 200)
-           ("A" a)
+           ("A" a :drawing-options `(:text-style ,(make-text-style nil :bold nil)))
            ("B" b)
            ("C" c)
-           ("Special Page" special-page :presentation-type 'special-page))
+           ("Special Page" special-page :presentation-type 'special-page
+                           :drawing-options `(:text-style ,(make-text-style nil nil :small))))
 	 io
 	 pointer-doc))))
 
@@ -137,4 +138,7 @@
 (define-tabdemo-command (com-paint-page-green :name t)
     ()
   (with-enabled-tab-layout-page page
-    (setf (getf (tab-page-drawing-options page) :ink) +green+)))
+    (setf (getf (tab-page-drawing-options page) :ink)
+          +green+
+          (getf (tab-page-drawing-options page) :text-style)
+          (make-text-style nil nil :small))))

--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -36,25 +36,25 @@
 (defpackage #:clim-tab-layout
   (:use #:clim #:clim-lisp)
   (:export #:tab-layout
-	   #:tab-layout-pane
-	   #:tab-layout-pages
-	   #:tab-page
-	   #:tab-page-tab-layout
-	   #:tab-page-title
-	   #:tab-page-pane
-	   #:tab-page-presentation-type
-	   #:tab-page-drawing-options
-	   #:add-page
-	   #:remove-page
-	   #:tab-layout-enabled-page
-	   #:sheet-to-page
-	   #:find-tab-page-named
-	   #:switch-to-page
-	   #:remove-page-named
-	   #:with-tab-layout
+           #:tab-layout-pane
+           #:tab-layout-pages
+           #:tab-page
+           #:tab-page-tab-layout
+           #:tab-page-title
+           #:tab-page-pane
+           #:tab-page-presentation-type
+           #:tab-page-drawing-options
+           #:add-page
+           #:remove-page
+           #:tab-layout-enabled-page
+           #:sheet-to-page
+           #:find-tab-page-named
+           #:switch-to-page
+           #:remove-page-named
+           #:with-tab-layout
            #:com-switch-to-tab-page
-	   #:com-remove-tab-page
-	   #:note-tab-page-changed))
+           #:com-remove-tab-page
+           #:note-tab-page-changed))
 
 (in-package #:clim-tab-layout)
 
@@ -85,16 +85,16 @@ to specify its contents when creating it dynamically using MAKE-PANE."))
    (title :initform nil :accessor tab-page-title :initarg :title)
    (pane :initform nil :accessor tab-page-pane :initarg :pane)
    (presentation-type :initform 'tab-page
-		      :accessor tab-page-presentation-type
-		      :initarg :presentation-type)
+                      :accessor tab-page-presentation-type
+                      :initarg :presentation-type)
    (enabled-callback :initform nil
-		     :accessor tab-page-enabled-callback
-		     :initarg :enabled-callback)
+                     :accessor tab-page-enabled-callback
+                     :initarg :enabled-callback)
    ;; fixme: drawing-options in this generality are a feature of the old
    ;; concrete tab pane.  Gtkairo will only look for the :INK in this list.
    (drawing-options :initform nil
-		    :accessor tab-page-drawing-options
-		    :initarg :drawing-options))
+                    :accessor tab-page-drawing-options
+                    :initarg :drawing-options))
   (:documentation "Instances of TAB-PAGE represent the pages in a TAB-LAYOUT.
 For each child pane, there is a TAB-PAGE providing the page's title and
 additional information about the child.  Valid initialization arguments
@@ -157,20 +157,20 @@ the TAB-LAYOUT implementation and specialized by its subclasses."))
   ;; do the call only after the change has been done:
   (let ((old-page (tab-layout-enabled-page parent)))
     (prog1
-	(call-next-method)
+        (call-next-method)
       (when (and page (not (equal page old-page)))
-	(note-tab-page-enabled page)))))
+        (note-tab-page-enabled page)))))
 
 (defmethod (setf tab-layout-pages) (newval (parent tab-layout))
   (unless (equal newval (remove-duplicates newval))
     (error "page list must not contain duplicates: ~A" newval))
   (let* ((oldval (tab-layout-pages parent))
-	 (add (set-difference newval oldval))
-	 (remove (set-difference oldval newval)))
+         (add (set-difference newval oldval))
+         (remove (set-difference oldval newval)))
     ;; check for errors
     (dolist (page add)
       (unless (null (tab-page-tab-layout page))
-	(error "~A has already been added to a different tab layout" page)))
+        (error "~A has already been added to a different tab layout" page)))
     ;; remove old pages first, because sheet-disown-child still needs access
     ;; to the original page list:
     (dolist (page remove)
@@ -204,10 +204,10 @@ to this sheet.  See also TAB-PAGE-PANE, the reverse operation."
 Note that uniqueness of titles is not enforced; the first page found will
 be returned."
   (find name
-	(tab-layout-pages tab-layout)
+        (tab-layout-pages tab-layout)
         :key #'tab-page-title
-	;; fixme: don't we want the case-sensitive STRING= here?
-	:test #'string-equal))
+        ;; fixme: don't we want the case-sensitive STRING= here?
+        :test #'string-equal))
 
 (defmethod (setf tab-page-title) :after (newval (page tab-page))
   (declare (ignore newval))
@@ -252,7 +252,7 @@ can also be called directly."
 SHEET-DISOWN-CHILD, which can also be used directly to remove the page's
 pane with the same effect."
   (sheet-disown-child (tab-page-tab-layout page)
-		      (tab-page-pane page)))
+                      (tab-page-pane page)))
 
 (defun remove-page-named (title tab-layout)
   "Remove the tab page with the specified TITLE from TAB-LAYOUT.
@@ -265,8 +265,8 @@ FIND-TAB-PAGE-NAMED to find and the remove a page yourself."
 ;;; creation macro
 
 (defmacro with-tab-layout ((default-presentation-type &rest initargs
-			     &key name &allow-other-keys)
-			   &body body)
+                             &key name &allow-other-keys)
+                           &body body)
   "Return a TAB-LAYOUT.  Any keyword arguments, including its name, will be
 passed to MAKE-PANE.  Child pages of the TAB-LAYOUT can be specified using
 BODY, using lists of the form (TITLE PANE &KEY PRESENTATION-TYPE
@@ -275,13 +275,13 @@ as :PRESENTATION-TYPE to pane creation forms that specify no type themselves."
   (let ((ptypevar (gensym)))
     `(let ((,ptypevar ,default-presentation-type))
        (make-pane 'tab-layout
-		  :name ,(or name `',(gensym "tab-layout-"))
-		  :pages (list ,@(mapcar (lambda (spec)
-					   `(make-tab-page ,@spec
-							   :presentation-type
-					     ,ptypevar))
-					 body))
-		  ,@initargs))))
+                  :name ,(or name `',(gensym "tab-layout-"))
+                  :pages (list ,@(mapcar (lambda (spec)
+                                           `(make-tab-page ,@spec
+                                                           :presentation-type
+                                             ,ptypevar))
+                                         body))
+                  ,@initargs))))
 
 (defun make-tab-page
     (title pane &key presentation-type drawing-options enabled-callback)
@@ -296,15 +296,15 @@ as :PRESENTATION-TYPE to pane creation forms that specify no type themselves."
 ;;; presentation/command system integration
 
 (define-command (com-switch-to-tab-page
-		 :command-table clim:global-command-table)
+                 :command-table clim:global-command-table)
     ((page 'tab-page :prompt "Tab page"))
   (switch-to-page page))
 
 (define-presentation-to-command-translator switch-via-tab-button
     (tab-page com-switch-to-tab-page clim:global-command-table
-	      :gesture :select
-	      :documentation "Switch to this page"
-	      :pointer-documentation "Switch to this page")
+              :gesture :select
+              :documentation "Switch to this page"
+              :pointer-documentation "Switch to this page")
     (object)
   (list object))
 
@@ -325,11 +325,11 @@ as :PRESENTATION-TYPE to pane creation forms that specify no type themselves."
   (stream-increment-cursor-position stream 5 0)
   (multiple-value-bind (x y) (stream-cursor-position stream)
     (let* ((length-top-line
-	    (+ x 6 (text-size stream (tab-page-title tab-page)) 3))
+            (+ x 6 (text-size stream (tab-page-title tab-page)) 3))
            (tab-button-polygon
-	    (list x (+ y 14)   (+ x 6) y
-		  (+ x 6) y   length-top-line y
-		  length-top-line y   (+ length-top-line 6) (+ y 14))))
+            (list x (+ y 14)   (+ x 6) y
+                  (+ x 6) y   length-top-line y
+                  length-top-line y   (+ length-top-line 6) (+ y 14))))
 
       ;; grey-filled polygone for the disabled panes
       (unless (sheet-enabled-p (tab-page-pane tab-page))
@@ -341,11 +341,11 @@ as :PRESENTATION-TYPE to pane creation forms that specify no type themselves."
       ;; "breach" the underline for the enabled pane
       (when (sheet-enabled-p (tab-page-pane tab-page))
         (draw-line stream
-		   (apply #'make-point (subseq tab-button-polygon 0 2))
-		   (apply #'make-point
-			  (subseq tab-button-polygon
-				  (- (length tab-button-polygon) 2)))
-		   :ink +background-ink+))))
+                   (apply #'make-point (subseq tab-button-polygon 0 2))
+                   (apply #'make-point
+                          (subseq tab-button-polygon
+                                  (- (length tab-button-polygon) 2)))
+                   :ink +background-ink+))))
 
   (stream-increment-cursor-position stream 8 0)
   (apply #'invoke-with-drawing-options stream
@@ -356,12 +356,12 @@ as :PRESENTATION-TYPE to pane creation forms that specify no type themselves."
   (stream-increment-cursor-position stream 10 0))
 
 (defclass tab-layout-pane (tab-layout)
-    ((header-pane :accessor tab-layout-header-pane
-		  :initarg :header-pane)
-     (header-display-function
-      :accessor header-display-function
-      :initarg :header-display-function
-      :initform 'default-display-tab-header))
+  ((header-pane :accessor tab-layout-header-pane
+                :initarg :header-pane)
+   (header-display-function
+    :accessor header-display-function
+    :initarg :header-display-function
+    :initform 'default-display-tab-header))
   (:documentation "A pure-lisp implementation of the tab-layout, this is
 the generic implementation chosen by the CLX frame manager automatically.
 Users should create panes for type TAB-LAYOUT, not TAB-LAYOUT-PANE, so
@@ -372,7 +372,7 @@ that the frame manager can customize the implementation."))
   (let ((old-page (tab-layout-enabled-page parent)))
     (unless (equal page old-page)
       (when old-page
-	(setf (sheet-enabled-p (tab-page-pane old-page)) nil)))
+        (setf (sheet-enabled-p (tab-page-pane old-page)) nil)))
     (when page
       (setf (sheet-enabled-p (tab-page-pane page)) t)))
   (call-next-method))
@@ -380,17 +380,17 @@ that the frame manager can customize the implementation."))
 (defun default-display-tab-header (tab-layout pane)
   (stream-increment-cursor-position pane 0 3)
   (draw-line* pane
-	      0
-	      17
+              0
+              17
               (1- (climi::pane-current-width pane))
-	      17
-	      :ink +black+)
+              17
+              :ink +black+)
   (mapc (lambda (page)
-	  (with-output-as-presentation
-	      (pane (tab-page-pane page)
-		    (tab-page-presentation-type page))
-	    (present page 'tab-page :stream pane)))
-	(tab-layout-pages tab-layout)))
+          (with-output-as-presentation
+              (pane (tab-page-pane page)
+                    (tab-page-presentation-type page))
+            (present page 'tab-page :stream pane)))
+        (tab-layout-pages tab-layout)))
 
 (defclass tab-bar-pane (application-pane)
   ()
@@ -405,12 +405,12 @@ that the frame manager can customize the implementation."))
     (dolist (page pages)
       (setf (sheet-enabled-p (tab-page-pane page)) (eq page current))))
   (let ((header
-	 (make-pane 'tab-bar-pane
-	  :display-time :command-loop
-	  :display-function
-	  (lambda (frame pane)
-	    (declare (ignore frame))
-	    (funcall (header-display-function instance) instance pane)))))
+         (make-pane 'tab-bar-pane
+          :display-time :command-loop
+          :display-function
+          (lambda (frame pane)
+            (declare (ignore frame))
+            (funcall (header-display-function instance) instance pane)))))
     (setf (tab-layout-header-pane instance) header)
     (sheet-adopt-child instance header)
     (setf (sheet-enabled-p header) t)))
@@ -428,16 +428,16 @@ that the frame manager can customize the implementation."))
 
 (defmethod allocate-space ((pane tab-layout-pane) width height)
   (let* ((header (tab-layout-header-pane pane))
-	 (y (space-requirement-height (compose-space header))))
+         (y (space-requirement-height (compose-space header))))
     (move-and-resize-sheet header 0 0 width y)
     (allocate-space header width y)
     (dolist (page (tab-layout-pages pane))
       (let ((child (tab-page-pane page)))
-	(move-and-resize-sheet child 0 y width (- height y))
-	(allocate-space child width (- height y))))))
+        (move-and-resize-sheet child 0 y width (- height y))
+        (allocate-space child width (- height y))))))
 
 (defmethod note-tab-page-changed
     ((layout tab-layout-pane) page)
   (redisplay-frame-pane (pane-frame layout)
-			(tab-layout-header-pane layout)
-			:force-p t))
+                        (tab-layout-header-pane layout)
+                        :force-p t))

--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -302,6 +302,8 @@ as :PRESENTATION-TYPE to pane creation forms that specify no type themselves."
 (define-presentation-to-command-translator switch-via-tab-button
     (tab-page com-switch-to-tab-page clim:global-command-table
               :gesture :select
+              :tester ((object)
+                       (not (sheet-enabled-p (tab-page-pane object))))
               :documentation "Switch to this page"
               :pointer-documentation "Switch to this page")
     (object)

--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -35,6 +35,8 @@
 
 (defpackage #:clim-tab-layout
   (:use #:clim #:clim-lisp)
+  (:import-from #:alexandria
+                #:when-let)
   (:export #:tab-layout
            #:tab-layout-pane
            #:tab-layout-pages
@@ -188,7 +190,7 @@ the TAB-LAYOUT implementation and specialized by its subclasses."))
 
 (defmethod sheet-disown-child :before ((parent tab-layout) child &key errorp)
   (declare (ignore errorp))
-  (alexandria:when-let ((page (sheet-to-page child)))
+  (when-let ((page (sheet-to-page child)))
     (setf (slot-value parent 'pages) (remove page (tab-layout-pages parent))
           (tab-page-tab-layout page) nil)
     (when (eq page (tab-layout-enabled-page parent))
@@ -211,23 +213,20 @@ be returned."
 
 (defmethod (setf tab-page-title) :after (newval (page tab-page))
   (declare (ignore newval))
-  (let ((layout (tab-page-tab-layout page)))
-    (when layout
-      (note-tab-page-changed layout page))))
+  (when-let ((layout (tab-page-tab-layout page)))
+    (note-tab-page-changed layout page)))
 
 (defmethod (setf tab-page-drawing-options) :after (newval (page tab-page))
   (declare (ignore newval))
-  (let ((layout (tab-page-tab-layout page)))
-    (when layout
-      (note-tab-page-changed layout page))))
+  (when-let ((layout (tab-page-tab-layout page)))
+    (note-tab-page-changed layout page)))
 
 (defmethod note-tab-page-changed ((layout tab-layout) page)
   nil)
 
 (defun note-tab-page-enabled (page)
-  (let ((callback (tab-page-enabled-callback page)))
-    (when callback
-      (funcall callback page))))
+  (when-let ((callback (tab-page-enabled-callback page)))
+    (funcall callback page)))
 
 
 ;;; convenience functions:

--- a/Extensions/layouts/tab-layout.lisp
+++ b/Extensions/layouts/tab-layout.lisp
@@ -422,8 +422,8 @@ that the frame manager can customize the implementation."))
            (mapcar #'compose-space (sheet-children pane))
            :initial-value
            (make-space-requirement
-            :min-width  0 :width  1 :max-width  clim:+fill+
-            :min-height 0 :height 1 :max-height clim:+fill+))))
+            :min-width  0 :width  1 :max-width  +fill+
+            :min-height 0 :height 1 :max-height +fill+))))
 
 (defmethod allocate-space ((pane tab-layout-pane) width height)
   (let* ((header (tab-layout-header-pane pane))


### PR DESCRIPTION
Mainly this:

![nicer-tab-highlight](https://user-images.githubusercontent.com/150189/29920170-8db59d7e-8e4c-11e7-9208-27337b767ed1.png)

Other than that:
* improve behavior of ``text-size`` for not fully specified text styles
* fix mop use method-browser example
* cleanup in tabdemo
* tab layout does not offer to switch to already selected tab