### PR TITLE
rewrite render backend %lerp to use octets

### DIFF
--- a/Extensions/render/color.lisp
+++ b/Extensions/render/color.lisp
@@ -35,7 +35,9 @@
 (declaim (inline %lerp)
 	 (ftype (function (octet octet octet) octet) %lerp))
 (defun %lerp (p q a)
-  (logand #xFF (+ p (octet-mult a (- q p)))))
+  (logand #xFF (if (>= q p)
+                   (+ p (octet-mult a (- q p)))
+                   (- p (octet-mult a (- p q))))))
 
 (declaim (inline %prelerp)
 	 (ftype (function (octet octet octet) octet) %prelerp))


### PR DESCRIPTION
 * before we would occasionally call octet-mult with a negative
   number. This worked, but the function declamation says it should
   only take octets and recent SBCL compilers are smart enough to see
   that we were violating this assumption. So, rewrite %lerp to always
   call octet-mult with bona fide octets.