### PR TITLE
Fix-164: Do not append keystrokes to *accelerator-gestures*

### DIFF
--- a/Core/clim-core/dialog.lisp
+++ b/Core/clim-core/dialog.lisp
@@ -266,8 +266,7 @@ accept of this query")))
 				  ,(query-identifier 
 				    (first
 				     (queries *accepting-values-stream*))))))
-	   (*accelerator-gestures* (append (compute-inherited-keystrokes command-table)
-					   *accelerator-gestures*)))
+	   (*accelerator-gestures* (compute-inherited-keystrokes command-table)))
       (letf (((frame-command-table *application-frame*)
               (find-command-table command-table)))
         (unwind-protect


### PR DESCRIPTION
Instead just overwrite them till the 'accepting-values' is active. it will be automatically restored when 'accepting-values' finishes. See #164.