### PR TITLE
Improve text field gadget

### DIFF
--- a/Core/clim-core/gadgets.lisp
+++ b/Core/clim-core/gadgets.lisp
@@ -1102,7 +1102,7 @@ and must never be nil.")
     :align-x :center
     :align-y :center
     :x-spacing 4
-    :y-spacing 2))
+    :y-spacing 4))
 
 (defmethod compose-space ((gadget push-button-pane) &key width height)
   (space-requirement+* (space-requirement+* (compose-label-space gadget)

--- a/Core/clim/text-editor-gadget.lisp
+++ b/Core/clim/text-editor-gadget.lisp
@@ -112,13 +112,11 @@
 (defmethod compose-space ((pane drei-text-field-substrate) &key width height)
   (declare (ignore width height))
   (with-sheet-medium (medium pane)
-    (let ((as (text-style-ascent (medium-text-style medium) medium))
-          (ds (text-style-descent (medium-text-style medium) medium))
-          (w  (text-size medium (gadget-value pane))))
-      (let ((width w)
-            (height (+ as ds)))
-        (make-space-requirement :height height :max-height height :min-height height
-                                                                  :min-width width :width width)))))
+    (let ((width (text-size medium (gadget-value pane)))
+	  (height (+ (stream-vertical-spacing pane)
+		     (text-style-height (medium-text-style medium) medium))))
+      (make-space-requirement :height height :min-height height :max-height height
+			      :width width :min-width width))))
 
 (defclass drei-text-editor-substrate (text-editor-substrate-mixin
                                       drei-editor-substrate)

--- a/Libraries/Drei/drei-redisplay.lisp
+++ b/Libraries/Drei/drei-redisplay.lisp
@@ -1068,7 +1068,7 @@ the end of the buffer."))
       (unless (zerop (* object-width stroke-height))
         (draw-rectangle* stream
                          cursor-x cursor-y
-                         (+ cursor-x object-width) (+ cursor-y stroke-height)
+                         (+ cursor-x 3) (+ cursor-y stroke-height)
                          :ink (ink cursor))))))
 
 (defmethod bounding-rectangle* ((view drei-buffer-view))


### PR DESCRIPTION
+ I have changed button spacing because It had very low padding. (`g` and `y` will touch the button boundry. see first column of buttons in `demodemo`)
+ Block cursor is replaced with a line cursor of `3` pixel width. Tested with listener, climacs and different editor widgets.
+ Fixed #317 .