### PR TITLE
Fix disabled quit option in pages menu of tabdemo.

### DIFF
--- a/Examples/tabdemo.lisp
+++ b/Examples/tabdemo.lisp
@@ -41,7 +41,7 @@
 		    :errorp nil
 		    :menu '(("Add Extra Pane" :command com-add-extra-pane)
 			    ("Randomize" :command com-randomize-tabdemo)
-			    ("Quit" :command com-quit-tabdemo)))
+			    ("Quit" :command com-quit)))
 
 (make-command-table 'tabdemo-properties-menu
 		    :errorp nil


### PR DESCRIPTION
The "Quit" menu option is disabled in the tabdemo.lisp example program; this commit changes the reference to nonexistent com-quit-tabdemo in the 'tabdemo-pages-menu command table to com-quit.