### PR TITLE
Develop

### DIFF
--- a/Backends/CLX/medium.lisp
+++ b/Backends/CLX/medium.lisp
@@ -961,15 +961,16 @@ time an indexed pattern is drawn.")
                      ((region-equal scan-line +nowhere+))
                      (filled (map-over-region-set-regions #'draw-line-1 scan-line))
                      (t (map-over-region-set-regions #'maybe-draw-border-points scan-line)))))
-          (if (<= width height)
-              (loop for x from x1 to (+ x1 width) do
-                   (draw-lines (region-intersection
-                                ellipse
-                                (make-line* x y1 x (+ y1 height)))))
-              (loop for y from y1 to (+ y1 height) do
-                   (draw-lines (region-intersection
-                                ellipse
-                                (make-line* x1 y (+ x1 width) y))))))))))
+          ;; O(n+m) because otherwise we may skip some points (better drawing quality)
+          (progn ;if (<= width height)
+            (loop for x from x1 to (+ x1 width) do
+                 (draw-lines (region-intersection
+                              ellipse
+                              (make-line* x y1 x (+ y1 height)))))
+            (loop for y from y1 to (+ y1 height) do
+                 (draw-lines (region-intersection
+                              ellipse
+                              (make-line* x1 y (+ x1 width) y))))))))))
 
 ;;; Round the parameters of the ellipse so that it occupies the expected pixels
 (defmethod medium-draw-ellipse* ((medium clx-medium) center-x center-y

--- a/Backends/CLX/medium.lisp
+++ b/Backends/CLX/medium.lisp
@@ -881,30 +881,55 @@ time an indexed pattern is drawn.")
             (vector-push-extend (- max-y min-y) points)))
         (xlib:draw-rectangles mirror gc points filled)))))
 
+(defun %ellipse-border-p (ellipse x-orig y-orig)
+  (with-slots (climi::tr climi::start-angle climi::end-angle) ellipse
+    (multiple-value-bind (x y) (untransform-position climi::tr x-orig y-orig)
+      (and (<= (- 1.0 .05) (+ (* x x) (* y y)) (+ 1.0 .05))
+           (or (null climi::start-angle)
+               (climi::%angle-between-p
+                (climi::%ellipse-position->angle ellipse x-orig y-orig)
+                climi::start-angle climi::end-angle))))))
+
 ;;; Round the parameters of the ellipse so that it occupies the expected pixels
 (defmethod medium-draw-ellipse* ((medium clx-medium) center-x center-y
 				 radius-1-dx radius-1-dy
 				 radius-2-dx radius-2-dy
 				 start-angle end-angle filled)
-  (unless (or (= radius-2-dx radius-1-dy 0) (= radius-1-dx radius-2-dy 0))
-    (error "MEDIUM-DRAW-ELLIPSE* not yet implemented for non axis-aligned ellipses."))
-  (with-transformed-position ((sheet-native-transformation (medium-sheet medium))
-                              center-x center-y)
-    (let* ((arc-angle (- end-angle start-angle))
-           (arc-angle (if (< arc-angle 0)
-                          (+ (* pi 2) arc-angle)
-                          arc-angle)))
-      (with-clx-graphics () medium
-        (let* ((radius-dx (abs (+ radius-1-dx radius-2-dx)))
-	       (radius-dy (abs (+ radius-1-dy radius-2-dy)))
-	       (min-x (round-coordinate (- center-x radius-dx)))
-	       (min-y (round-coordinate (- center-y radius-dy)))
-	       (max-x (round-coordinate (+ center-x radius-dx)))
-	       (max-y (round-coordinate (+ center-y radius-dy))))
-          (xlib:draw-arc mirror gc
-                         min-x min-y (- max-x min-x) (- max-y min-y)
-                         (mod start-angle (* 2 pi)) arc-angle
-                         filled))))))
+  (if (or (= radius-2-dx radius-1-dy 0) (= radius-1-dx radius-2-dy 0))
+      (with-transformed-position ((sheet-native-transformation (medium-sheet medium))
+                                  center-x center-y)
+        (let* ((arc-angle (- end-angle start-angle))
+               (arc-angle (if (< arc-angle 0)
+                              (+ (* pi 2) arc-angle)
+                              arc-angle)))
+          (with-clx-graphics () medium
+            (let* ((radius-dx (abs (+ radius-1-dx radius-2-dx)))
+                   (radius-dy (abs (+ radius-1-dy radius-2-dy)))
+                   (min-x (round-coordinate (- center-x radius-dx)))
+                   (min-y (round-coordinate (- center-y radius-dy)))
+                   (max-x (round-coordinate (+ center-x radius-dx)))
+                   (max-y (round-coordinate (+ center-y radius-dy))))
+              (xlib:draw-arc mirror gc
+                             min-x min-y (- max-x min-x) (- max-y min-y)
+                             (mod start-angle (* 2 pi)) arc-angle
+                             filled)))))
+      ;; As a proof of concept we go after slow method which probes for each point
+      ;; in the bounding rectangle if ellipse contains it. Then we draw a
+      ;; pixel. We should optimize it by approximating them with bezier areas.
+      (let ((ellipse (make-ellipse* center-x center-y
+                                    radius-1-dx radius-1-dy
+                                    radius-2-dx radius-2-dy
+                                    :start-angle start-angle :end-angle end-angle))
+            (belongs-p (if filled
+                           #'region-contains-position-p
+                           #'%ellipse-border-p)))
+        (multiple-value-bind (x1 y1 width height)
+            (region->clipping-values (bounding-rectangle ellipse))
+          (with-clx-graphics () medium
+            (loop for x from x1 to (+ x1 width) do
+                 (loop for y from y1 to (+ y1 height) do
+                      (when (funcall belongs-p ellipse x y)
+                        (xlib:draw-point mirror gc x y)))))))))
 
 (defmethod medium-draw-circle* ((medium clx-medium)
 				center-x center-y radius start-angle end-angle

--- a/Core/clim-basic/medium.lisp
+++ b/Core/clim-basic/medium.lisp
@@ -697,6 +697,14 @@
                                                right top)
                                 t filled)))))
 
+(defmethod medium-draw-ellipse* :around (medium center-x center-y
+                                         radius-1-dx radius-1-dy radius-2-dx radius-2-dy
+                                         start-angle end-angle filled)
+  (when (<= (abs (- (mod start-angle (* 2 pi)) (mod end-angle (* 2 pi)))) short-float-epsilon)
+    (setf start-angle 0
+          end-angle (* 2 pi)))
+  (call-next-method))
+
 (defmethod medium-draw-ellipse* :around ((medium transform-coordinates-mixin) center-x center-y
                                          radius-1-dx radius-1-dy radius-2-dx radius-2-dy
                                          start-angle end-angle filled)
@@ -716,6 +724,12 @@
                           radius-1-dx radius-1-dy
                           radius-2-dx radius-2-dy
                           start-angle end-angle filled)))))
+
+(defmethod medium-draw-circle* :around (medium center-x center-y
+                                        radius start-angle end-angle filled)
+  (when (<= (abs (- (mod start-angle (* 2 pi)) (mod end-angle (* 2 pi)))) short-float-epsilon)
+    (setf start-angle 0 end-angle (* 2 pi)))
+  (call-next-method))
 
 (defmethod medium-draw-circle* :around ((medium transform-coordinates-mixin) center-x center-y
                                          radius start-angle end-angle filled)

--- a/Core/clim-basic/regions.lisp
+++ b/Core/clim-basic/regions.lisp
@@ -95,7 +95,11 @@
 (defgeneric region-set-regions (region &key normalize))
 (defgeneric map-over-region-set-regions (function region &key normalize))
 (defgeneric region-union (region1 region2))
-(defgeneric region-intersection (region1 region2))
+(defgeneric region-intersection (region1 region2)
+  (:method :around ((a region) (b region))
+           (cond ((ignore-errors (region-contains-region-p a b)) b)
+                 ((ignore-errors (region-contains-region-p b a)) a)
+                 (t (call-next-method)))))
 (defgeneric region-difference (region1 region2))
 
 ;;; -- 2.5.2 CLIM Point Objects ----------------------------------------------

--- a/Core/clim-basic/regions.lisp
+++ b/Core/clim-basic/regions.lisp
@@ -833,6 +833,17 @@
 (defmethod region-intersection ((ellipse standard-ellipse) (line standard-line))
   (region-intersection line ellipse))
 
+(defmethod region-contains-region-p ((a standard-ellipse) (b standard-ellipse))
+  (multiple-value-bind (bcx bcy) (ellipse-center-point* b)
+    (and (region-contains-position-p a bcx bcy)
+         (null (intersection-ellipse/ellipse a b))
+         (or (null (ellipse-start-angle a))
+             (multiple-value-bind (sx sy) (%ellipse-angle->position a (ellipse-start-angle a))
+               (multiple-value-bind (ex ey) (%ellipse-angle->position a (ellipse-end-angle a))
+                 (multiple-value-bind (cx cy) (ellipse-center-point* a)
+                   (and (null (region-intersection b (make-line* sx sy cx cy)))
+                        (null (region-intersection b (make-line* ex ey cx cy)))))))))))
+
 ;;; Ellipse is a convex object. That Implies that if each of the rectangle
 ;;; vertexes lies inside it, then whole rectangle fits as well. We take a
 ;;; special care for ellipses with start/end angle.

--- a/Core/clim-basic/regions.lisp
+++ b/Core/clim-basic/regions.lisp
@@ -1633,6 +1633,24 @@ point of the resulting line."
                    (t
                     ;;paralell -- kein Schnitt
                     nil)))
+            ((or (zerop dx) (zerop du))
+             ;; infinite slope (vertical line) - previous case covers two vlines
+             (let (a b x y)
+               (if (zerop dx)           ; ugly setf - I'm ashamed
+                   (setf a (/ dv du)
+                         b (- v1 (* a u1))
+                         x x1
+                         y (+ (* a x1) b))
+                   (setf a (/ dy dx)
+                         b (- y1 (* a x1))
+                         x u1
+                         y (+ (* a x) b)))
+               (if (and (or (<= x1 x x2) (<= x2 x x1))
+                        (or (<= u1 x u2) (<= u2 x u1))
+                        (or (<= y1 y y2) (<= y2 y y1))
+                        (or (<= v1 y v2) (<= v2 y v1)))
+                   (values :hit x y)
+                   nil)))
             (t
              (let ((x (/ (+ (* dx (- (* u1 dv) (* v1 du)))
 			    (* du (- (* y1 dx) (* x1 dy))))

--- a/Core/clim-basic/regions.lisp
+++ b/Core/clim-basic/regions.lisp
@@ -642,6 +642,18 @@
   (with-slots (tr) self
     (multiple-value-bind (x y) (untransform-position tr x y)
       (<= (+ (* x x) (* y y)) 1))))
+(defun %ellipse-angle->position (ellipse angle)
+  (with-slots (tr) ellipse
+    (let* ((el-angle (untransform-angle tr angle))
+           (x0 (cos el-angle))
+           ;; reverted axis
+           (y0 (sin el-angle)))
+      (transform-position tr x0 (- y0)))))
+
+(defun %ellipse-position->angle (ellipse x y)
+  (multiple-value-bind (xc yc) (ellipse-center-point* ellipse)
+    ;; remember, that y-axis is reverted
+    (coordinate (atan* (- x xc) (- (- y yc))))))
 
 (defmethod bounding-rectangle* ((region standard-ellipse))
   ;; XXX start/end angle still missing

--- a/Core/clim-basic/regions.lisp
+++ b/Core/clim-basic/regions.lisp
@@ -2503,7 +2503,10 @@
 (defmethod region-contains-region-p ((a region) (b region))
   (or (eq a b)
       (region-equal +nowhere+ (region-difference b a))))
-  
+
+(defmethod region-contains-region-p ((a standard-rectangle) (b bounding-rectangle))
+  (or (eq a b)
+      (region-equal +nowhere+ (region-difference (bounding-rectangle b) a))))
 ;;;; ===========================================================================
 
 (defmethod bounding-rectangle* ((a standard-line))

--- a/Core/clim-core/gadgets.lisp
+++ b/Core/clim-core/gadgets.lisp
@@ -2856,13 +2856,12 @@ if INVOKE-CALLBACK is given."))
                          (progn ,@body)))
                   (setf (gadget record)
                         (with-output-as-gadget-body ,stream)))))
-         (declare (dynamic-extent #'with-output-as-gadget-continuation
-                                  #'gadget-output-record-constructor))
+         (declare (dynamic-extent #'with-output-as-gadget-continuation))
          (let ((,gadget-output-record
                 (invoke-with-output-to-output-record
                  ,stream
                  #'with-output-as-gadget-continuation
-                 'gadget-output-record :x ,x :y ,y)))
+                 'gadget-output-record :x ,x :y ,y ,@options)))
            (setup-gadget-record ,stream ,gadget-output-record)
            (stream-add-output-record ,stream ,gadget-output-record)
            (values (gadget ,gadget-output-record) ,gadget-output-record))))))

--- a/Examples/drawing-tests.lisp
+++ b/Examples/drawing-tests.lisp
@@ -1,8 +1,5 @@
 (in-package :clim-demo)
 
-(defun run-drawing-tests ()
-  (run-frame-top-level (make-instance 'drawing-tests)))
-
 (defparameter *drawing-tests* (make-hash-table :test 'equal))
 
 (defparameter *width* 500)

--- a/Examples/drawing-tests.lisp
+++ b/Examples/drawing-tests.lisp
@@ -1,5 +1,8 @@
 (in-package :clim-demo)
 
+(defun run-drawing-tests ()
+  (run-frame-top-level (make-instance 'drawing-tests)))
+
 (defparameter *drawing-tests* (make-hash-table :test 'equal))
 
 (defparameter *width* 500)

--- a/Examples/package.lisp
+++ b/Examples/package.lisp
@@ -1,4 +1,4 @@
 
 (defpackage #:clim-demo
   (:use #:clim-extensions #:clim #:clim-lisp)
-  (:export #:demodemo))
+  (:export #:demodemo #:run-drawing-tests))


### PR DESCRIPTION
- core improvements (design etc)
- ellipse region implementation
- clx clipping region may be arbitrary region
- we can draw ellipses which are no xy-aligned
- new demos for clim-examples with descriptions

I suggest going through commits one by one - they are cleaned up with short descriptions of changes. I have rearranged their order a few times to make them more readable and locally relatable.