### PR TITLE
Improve CLX-fb experience by fixing distribute-event for single-mirro…

### DIFF
--- a/Core/clim-basic/utils.lisp
+++ b/Core/clim-basic/utils.lisp
@@ -548,3 +548,13 @@ STREAM in the direction DIRECTION."
 (defun keyword-arg-name-from-symbol (symbol)
   (let ((name (symbol-name symbol)))
     (string-capitalize (substitute #\Space #\- name))))
+
+;;; taken from https://stackoverflow.com/questions/11067899/is-there-a-generic-method-for-cloning-clos-objects#11068536, use with care (should work for "ordinary" classes though).
+(defun shallow-copy-object (original)
+  (let* ((class (class-of original))
+         (copy (allocate-instance class)))
+    (dolist (slot (mapcar #'c2mop:slot-definition-name (c2mop:class-slots class)))
+      (when (slot-boundp original slot)
+        (setf (slot-value copy slot)
+              (slot-value original slot))))
+    copy))


### PR DESCRIPTION
…red-sheet

Recent change in event hierarchy (introducing pointer-button-event and
pointer-scroll-event) caused some regressions in CLX-fb.

single-mirrored-sheet (like CLX-fb) requiers some juggling with sheets to
distribute events. On the other hand events are immutable, so we had to make a
new instance if we wanted to augment event sheet.

Since different pointer events have different slots (delta-x, button etc) we
need an utility to make event shallow copy (which we can modify without
violating the spec). Thanks to that scrolling started working on CLX-fb (just
like it works on normal CLX) and regression is fixed.

Extra benefit is the fact that code is simplier now (39 insertions vs 63
deletions).

How to test CLX-fb:

> (ql:quickload '(clim-examples mcclim-clx-fb))
> (let ((clim:*default-server-path* :clx-fb))
    (clim-demo:demodemo))