### PR TITLE
Fittestbits/demo fixes

### DIFF
--- a/Backends/CLX/medium.lisp
+++ b/Backends/CLX/medium.lisp
@@ -1076,7 +1076,7 @@ time an indexed pattern is drawn.")
   (text-style-character-width text-style medium #\m))
 
 (defmethod text-style-fixed-width-p (text-style (medium clx-medium))
-  (eql (text-style-family text-style) :fix))
+  (eql (text-style-family text-style) :fixed))
 
 (eval-when (:compile-toplevel :execute)
   ;; ASCII / CHAR-CODE compatibility checking

--- a/Examples/demodemo.lisp
+++ b/Examples/demodemo.lisp
@@ -18,8 +18,8 @@
 ;;; Library General Public License for more details.
 ;;;
 ;;; You should have received a copy of the GNU Library General Public
-;;; License along with this library; if not, write to the 
-;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330, 
+;;; License along with this library; if not, write to the
+;;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 ;;; Boston, MA  02111-1307  USA.
 
 (in-package :clim-demo)
@@ -52,7 +52,7 @@ denoted by this symbol."
         (run-frame-top-level frame))
     frame))
 
-(define-application-frame demodemo 
+(define-application-frame demodemo
     () ()
     (:menu-bar nil)
     (:layouts
@@ -116,7 +116,7 @@ denoted by this symbol."
 (defun demodemo ()
   (run-frame-top-level (make-application-frame 'demodemo)))
 
-(define-application-frame hbox-test 
+(define-application-frame hbox-test
     () ()
     (:layouts
      (default
@@ -131,7 +131,7 @@ denoted by this symbol."
            5
            ) )))
 
-(define-application-frame table-test 
+(define-application-frame table-test
     () ()
     (:layouts
      (default
@@ -162,7 +162,7 @@ denoted by this symbol."
                      :background +PALETURQUOISE4+
                      :text-style (make-text-style :sans-serif :roman :normal))
     #+nil
-    (make-pane 'push-button :label 
+    (make-pane 'push-button :label
                :text-style (make-text-style :sans-serif :roman :normal)
                :max-width 1000
                :max-height 1000)))
@@ -300,7 +300,7 @@ denoted by this symbol."
   (setf (list-pane-items (find-pane-named *application-frame* 'result-list))
 	(apropos-list (gadget-value
 		       (find-pane-named *application-frame* 'substring))
-		      :clim t)))
+		      :clim #+sbcl t)))
 
 (define-application-frame option-test
     () ()

--- a/Extensions/render/backend/port.lisp
+++ b/Extensions/render/backend/port.lisp
@@ -56,7 +56,7 @@
                  family (or family :fix)
                  size   (or size :normal)
 		 size (getf *text-sizes* size size))
-                 	   
+
            (when (eq family :fixed)
              (setf family :fix))
            (find-and-make-truetype-font family face size))))
@@ -65,6 +65,11 @@
               (or (find-truetype-font text-style)
                   (invoke-with-truetype-path-restart #'find-font))))))
 
+(defmethod text-style-to-font ((port render-port-mixin) (gs-text-style cons))
+  (text-style-to-font port (apply #'make-text-style gs-text-style)))
+
+(defmethod clim-internals::text-style-size ((gs-text-style cons))
+  (caddr gs-text-style))
 
 (defmethod clim-extensions:port-all-font-families :around
     ((port render-port-mixin) &key invalidate-cache)


### PR DESCRIPTION
Change CLX/medium.lisp so that text-style-fixed-width-p checks for family :fixed in stead of :fix.

Change Examples/demodemo.lisp so that a call to apropos-list only has three arguments when using SBCL, since the third argument does not seem to be part of the common lisp spec. and is not supported by CLISP or Mezzano.

Change Extensions/render/backend/port.lisp to support gs-...-mixin. (gs = graph-state) For, graph state, medium-text-style is a list of (<family> <face> <size>) instead of a standard-text-style. Added methods text-style-to-font and text-style-size methods to support this type of medium-text-style.