### PR TITLE
There is no overwrite-mode slot in textual-drei-syntax-view class

### DIFF
--- a/Libraries/Drei/core-commands.lisp
+++ b/Libraries/Drei/core-commands.lisp
@@ -39,8 +39,8 @@ When overwrite is on, an object entered on the keyboard
 will replace the object after the point. 
 When overwrite is off (the default), objects are inserted at point. 
 In both cases point is positioned after the new object."
-  (with-slots (overwrite-mode) (current-view)
-    (setf overwrite-mode (not overwrite-mode))))
+  (setf (overwrite-mode (current-view))
+        (not (overwrite-mode (current-view)))))
 
 (set-key 'com-overwrite-mode
 	 'editing-table


### PR DESCRIPTION
This little change resolves the following error when insert key is pressed to turn on overwrite mode in text-field-pane:
```
When attempting to read the slot's value (slot-value), the slot
DREI:OVERWRITE-MODE is missing from the object
#<DREI:TEXTUAL-DREI-SYNTAX-VIEW name: *scratch* 1 {1006EBF113}>.
   [Condition of type SIMPLE-ERROR]

Restarts:
 0: [ABORT] Return to application command loop
 1: [RETRY] Retry SLY mREPL evaluation request.
 2: [*ABORT] Return to SLY's top level.
 3: [ABORT] abort thread (#<THREAD "sly-channel-1-mrepl-remote-1" RUNNING {10043B58E3}>)
```