### PR TITLE
Improve image -> pattern code by calling specific opticl functions.

### DIFF
--- a/Extensions/bitmap-formats/bitmaps.lisp
+++ b/Extensions/bitmap-formats/bitmaps.lisp
@@ -11,12 +11,26 @@
   (:documentation "This condition is signaled when trying to read a
   bitmap file whose format is not supported." ))
 
-(defun opticl-read-bitmap-file (image-pathname)
-  (let* ((img (handler-case
-                  (opticl:read-image-file image-pathname)
-                (error ()
-                  (error 'unsupported-bitmap-format))))
-         (height (array-dimension img 0))
+(defmacro define-opticl-reader (name opticl-reader)
+  `(defun ,name (image-pathname)
+     (let* ((img (handler-case
+                     (,opticl-reader image-pathname)
+                   (error ()
+                     (error 'unsupported-bitmap-format)))))
+       (convert-opticl-img img))))
+
+(define-opticl-reader opticl-read-bitmap-file opticl:read-image-file)
+(define-opticl-reader opticl-read-gif-file opticl:read-gif-file)
+(define-opticl-reader opticl-read-jpg-file opticl:read-jpeg-file)
+(define-opticl-reader opticl-read-pbm-file opticl:read-pbm-file)
+(define-opticl-reader opticl-read-pgm-file opticl:read-pgm-file)
+(define-opticl-reader opticl-read-png-file opticl:read-png-file)
+(define-opticl-reader opticl-read-pnm-file opticl:read-pnm-file)
+(define-opticl-reader opticl-read-ppm-file opticl:read-ppm-file)
+(define-opticl-reader opticl-read-tiff-file opticl:read-tiff-file)
+
+(defun convert-opticl-img (img)
+  (let* ((height (array-dimension img 0))
          (width (array-dimension img 1))
          (array (make-array (list height width)
                             :element-type '(unsigned-byte 32))))

--- a/Extensions/image/bitmap.lisp
+++ b/Extensions/image/bitmap.lisp
@@ -70,3 +70,30 @@ significant octets being the values R, G and B, in order."
 
 (define-bitmap-file-reader :pixmap-3 (pathname)
   (read-bitmap-file pathname :format :xpm))
+
+(define-bitmap-file-reader :gif (pathname)
+  (opticl-read-gif-file pathname))
+
+(define-bitmap-file-reader :jpg (pathname)
+  (opticl-read-jpg-file pathname))
+
+(define-bitmap-file-reader :jpeg (pathname)
+  (opticl-read-jpg-file pathname))
+
+(define-bitmap-file-reader :pbm (pathname)
+  (opticl-read-pbm-file pathname))
+
+(define-bitmap-file-reader :pgm (pathname)
+  (opticl-read-pgm-file pathname))
+
+(define-bitmap-file-reader :png (pathname)
+  (opticl-read-png-file pathname))
+
+(define-bitmap-file-reader :pnm (pathname)
+  (opticl-read-pnm-file pathname))
+
+(define-bitmap-file-reader :ppm (pathname)
+  (opticl-read-ppm-file pathname))
+
+(define-bitmap-file-reader :tiff (pathname)
+  (opticl-read-tiff-file pathname))

--- a/Extensions/image/package.lisp
+++ b/Extensions/image/package.lisp
@@ -8,6 +8,14 @@
                 #:pattern-width
                 #:pattern-height
                 #:opticl-read-bitmap-file
+                #:opticl-read-gif-file
+                #:opticl-read-jpg-file
+                #:opticl-read-pbm-file
+                #:opticl-read-pgm-file
+                #:opticl-read-png-file
+                #:opticl-read-pnm-file
+                #:opticl-read-ppm-file
+                #:opticl-read-tiff-file
                 #:medium-draw-pattern*
                 #:def-grecording
                 #:defrecord-predicate


### PR DESCRIPTION
opticl isn't great at guessing file types. It appears to use the file extension in order to guess, which isn't always correct.

In cases where the user is providing a `:format` argument, we shouldn't make opticl try to guess, since the user has told us what format the file is. The current code ignores the ':format' argument for common formats that opticl is used to decode. This fixes that.

Previously, these didn't work - opticl couldn't guess because of the lack of an extension - but now they do:
```
CL-USER> (clim:make-pattern-from-bitmap-file "/home/kyle/Documents/12pbm" :format :pbm)
#<CLIM-EXTENSIONS:RGB-PATTERN {10309BD053}>                                                                                                                                                          
CL-USER> (clim:make-pattern-from-bitmap-file "/home/kyle/Documents/12pgm" :format :pgm)
#<CLIM-EXTENSIONS:RGB-PATTERN {1030A18113}>                                                                                                                                                          
CL-USER> (clim:make-pattern-from-bitmap-file "/home/kyle/Documents/12tiff" :format :tiff)
#<CLIM-EXTENSIONS:RGB-PATTERN {1030FFB3B3}> 
```

Of course, it still falls back on previous behavior for any formats not explicitly specified.
The formats I've identified are:
```
gif
jpg
pbm
pgm
png
pnm
ppm
tiff
```
Which are all the ones opticl can decode, as far as I can tell.

