### PR TITLE
ux: text-selection: be more specific with the mixin

### DIFF
--- a/Core/clim-basic/repaint.lisp
+++ b/Core/clim-basic/repaint.lisp
@@ -203,8 +203,8 @@ want to do the same.")
            (native-sheet-region (effective-repaint-region parent sheet region)))
       (with-sheet-medium (medium parent)
 	(with-drawing-options (medium :clipping-region native-sheet-region
-				      :ink
-                                      #-jd-test(pane-background sheet)
+				      :ink (medium-background medium)
+                                      #+jd-test(pane-background sheet)
                                       #+jd-test(alexandria:random-elt
                                                 (list +darkmagenta+
                                                       +darkblue+

--- a/Core/clim-basic/stream-input.lisp
+++ b/Core/clim-basic/stream-input.lisp
@@ -76,9 +76,10 @@
 ;;; what we've got after it returns.
 
 (defclass standard-input-stream (fundamental-character-input-stream
-				 standard-sheet-input-mixin)
+                                 standard-sheet-input-mixin
+                                 cut-and-paste-mixin)
   ((unread-chars :initform nil
-		 :accessor stream-unread-chars)))
+                 :accessor stream-unread-chars)))
 
 (defmethod stream-read-char ((pane standard-input-stream))
   (if (stream-unread-chars pane)

--- a/Core/clim-basic/stream-output.lisp
+++ b/Core/clim-basic/stream-output.lisp
@@ -27,7 +27,7 @@
 ;;;       happens to be an output-recording-stream. - MikeMac 1/7/99
 
 ;;; Standard-Output-Stream class
-(defclass standard-output-stream (output-stream) ())
+(defclass standard-output-stream (output-stream cut-and-paste-mixin) ())
 
 (defmethod stream-recording-p ((stream output-stream)) nil)
 (defmethod stream-drawing-p ((stream output-stream)) t)

--- a/Core/clim-basic/text-selection.lisp
+++ b/Core/clim-basic/text-selection.lisp
@@ -52,12 +52,6 @@
 
 (defparameter *marking-border* 1)
 
-(defparameter *marked-foreground* +dark-red+
-  "Foreground ink to use for marked stuff.")
-
-(defparameter *marked-background* +light-yellow+
-  "Background ink to use for marked stuff.")
-
 ;;;; Text Selection Protocol
 
 (defgeneric release-selection (port &optional time)
@@ -150,22 +144,27 @@ the incoming selection."))
 
 (defmethod handle-repaint :around ((pane cut-and-paste-mixin) region)
   (with-slots (markings) pane
-    (cond ((null markings)
-           (call-next-method))
-          (t
-           (let ((marked-region
-                  (reduce #'region-union (mapcar #'(lambda (x) (marking-region pane x)) (slot-value pane 'markings))
-                          :initial-value +nowhere+)))
-             (with-sheet-medium (medium pane)
-               (let ((R (region-difference region marked-region)))
-                 (with-drawing-options (medium :clipping-region R)
-                   (call-next-method pane R))))
-             (with-sheet-medium (medium pane)
-               (let ((R (region-intersection region marked-region)))
-                 (with-drawing-options (medium :clipping-region R)
-                   (letf (((medium-foreground medium) *marked-foreground*)
-                          ((medium-background medium) *marked-background*))
-                     (call-next-method pane R))))))))))
+    (when (null markings)
+      (return-from handle-repaint (call-next-method)))
+    (let ((marked-region
+           (reduce #'region-union (mapcar #'(lambda (x)
+                                              (marking-region pane x))
+                                          (slot-value pane 'markings))
+                   :initial-value +nowhere+)))
+      (with-sheet-medium (medium pane)
+        (let ((R (region-difference region marked-region)))
+          (with-drawing-options (medium :clipping-region R)
+            (call-next-method pane R))))
+      (with-sheet-medium (medium pane)
+        (let ((R (region-intersection region marked-region)))
+          (with-drawing-options (medium :clipping-region R)
+            (let* ((fg (medium-foreground medium))
+                   (bg (medium-background medium))
+                   (new-fg (if (eql fg clim:+black+) +dark-red+ bg))
+                   (new-bg (if (eql bg clim:+white+) +light-yellow+ fg)))
+              (letf (((medium-foreground medium) new-fg)
+                     ((medium-background medium) new-bg))
+                (call-next-method pane R)))))))))
 
 (defgeneric eos/shift-click (pane event))
 

--- a/Core/clim-basic/text-selection.lisp
+++ b/Core/clim-basic/text-selection.lisp
@@ -52,10 +52,10 @@
 
 (defparameter *marking-border* 1)
 
-(defparameter *marked-foreground* +white+
+(defparameter *marked-foreground* +dark-red+
   "Foreground ink to use for marked stuff.")
 
-(defparameter *marked-background* +blue4+
+(defparameter *marked-background* +light-yellow+
   "Background ink to use for marked stuff.")
 
 ;;;; Text Selection Protocol

--- a/Core/clim-core/panes.lisp
+++ b/Core/clim-core/panes.lisp
@@ -802,7 +802,7 @@ which changed during the current execution of CHANGING-SPACE-REQUIREMENTS.
 (defclass basic-pane (standard-space-requirement-options-mixin
                       sheet-parent-mixin ;mirrored-sheet-mixin
                       ;; UX mixins
-                      cut-and-paste-mixin
+                      ;cut-and-paste-mixin
                       mouse-wheel-scroll-mixin
                       ;; protocol class with million mixins goes last
                       pane)


### PR DESCRIPTION
- previously mixin was specialized on a pane, but methods were specialized on
  extended streams, what lead to erros when trying to select on (for instance) a
  gadget - now we mix it in onlhy for standard-input-stream and
  standard-output-stream what resolves this (unreported) issue;

- in repaint protocol we have used pane-background instead of medium-background
  what lead to regression in drawing text-selection background - we fix
  that (closes #470);

- previously selection background was blue and text was white – I've changed to
  to while-yellow/red what imho looks much better - very opinionated tweak.