### PR TITLE
Freetype: Don't try to parse text styles in list form

### DIFF
--- a/Extensions/fonts/freetype.lisp
+++ b/Extensions/fonts/freetype.lisp
@@ -611,15 +611,10 @@ or NIL if the current transformation is the identity transformation."
                                        (font-replacement-text-style text-style)
                                        (otherwise nil)))))))
 
-(defmethod climb:text-style-to-font ((port clx-freetype-port) text-style)
-  (etypecase text-style
-    (clim:standard-text-style
-     (let ((x (or (clim:text-style-mapping port text-style)
-                  (setf (clim:text-style-mapping port text-style)
-                        (find-freetype-font port text-style)))))
-       x))
-    (climi::device-font-text-style
-     nil)))
+(defmethod climb:text-style-to-font ((port clx-freetype-port) (text-style clim:standard-text-style))
+  (or (clim:text-style-mapping port text-style)
+      (setf (clim:text-style-mapping port text-style)
+            (find-freetype-font port text-style))))
 
 ;;;
 ;;;  List fonts


### PR DESCRIPTION
The method TEXT-STYLE-TO-FONT can be called with a list as argument.
This specifically happened in the "German towns" demo when clicking on
a town on the map.

This changes the method so that it only specialises on
STANDARD-TEXT-STYLE.