### PR TITLE
Fix the initargs in open-window-stream so that gadgets in own-window …

### DIFF
--- a/Core/clim-core/frames/window-stream.lisp
+++ b/Core/clim-core/frames/window-stream.lisp
@@ -89,8 +89,8 @@
                        :height height
                        :scroll-bars scroll-bars
                        (typecase input-buffer
-                         (event-queue (list :event-queue input-buffer))
-                         (vector      (list :input-buffer input-buffer))
+                         (event-queue (list :frame-event-queue input-buffer))
+                         (vector      (list :frame-input-buffer input-buffer))
                          (otherwise   nil)))))
     ;; Adopt and enable the pane
     (when (eq (frame-state frame) :disowned)


### PR DESCRIPTION
This addresses issue #1219 (and #1129).  The problem is that gadgets don't work in an accepting-values when own-window = t.

The cause of the problem is in open-window-stream.  It provides init-args to make-application-frame depending on the type of the input-buffer argument that is passed in.  The init-args it provides are
either :event-queue or :input-buffer, but they should be :frame-event-queue and :frame-input-buffer.

This fixes that.