### PR TITLE
ttf fonts: map default text styles with cl-dejavu fonts

### DIFF
--- a/Backends/CLX/fonts-xrender.lisp
+++ b/Backends/CLX/fonts-xrender.lisp
@@ -16,9 +16,6 @@
 
 ;;;; Notes
 
-;;; You might need to tweak mcclim-truetype:*families/faces* to point
-;;; to where ever there are suitable TTF fonts on your system.
-
 ;;; FIXME: Not particularly thread safe.
 
 
@@ -177,23 +174,12 @@ The following files should exist:~&~{  ~A~^~%~}"
   (declare (ignore character-set))
   (labels
       ((find-and-make-truetype-font (family face size)
-         (let* ((font-path-maybe-relative
-                  (cdr (assoc (list family face) mcclim-truetype:*families/faces*
-                              :test #'equal)))
-                (font-path
-                  (and font-path-maybe-relative
-                       (case (car (pathname-directory
-                                   font-path-maybe-relative))
-                         (:absolute font-path-maybe-relative)
-                         (otherwise
-                          (merge-pathnames
-                           font-path-maybe-relative
-                           (or mcclim-truetype:*truetype-font-path* "")))))))
+         (let* ((font-path
+                  (assoc-value mcclim-truetype:*families/faces*
+                               (list family face) :test #'equal)))
            (if (and font-path (probe-file font-path))
                (make-truetype-font port font-path size)
-               (error 'missing-font
-                      :filename font-path
-                      :text-style text-style))))
+               (error 'missing-font :filename font-path :text-style text-style))))
        (find-font ()
          (multiple-value-call #'find-and-make-truetype-font
            (clim:text-style-components text-style))))

--- a/Backends/RasterImage/package.lisp
+++ b/Backends/RasterImage/package.lisp
@@ -21,20 +21,6 @@
                   ;;#:save-image-to-file
                   ;;#:save-image-to-stream
                   )
-    (:import-from :mcclim-truetype
-                  #:glyph-pixarray
-                  #:ensure-gethash
-                  #:invoke-with-truetype-path-restart
-                  #:*truetype-font-path*
-                  #:*family-names*
-                  #:zpb-ttf-font-loader
-                  #:*zpb-font-lock*
-                  #:*fontconfig-faces*
-                  #:*families/faces*
-                  #:truetype-device-font-name
-                  #:fontconfig-font-name
-                  #:make-truetype-device-font-name
-                  #:make-fontconfig-font-name)
     (:export
      #:with-output-to-raster-image-stream
      #:with-output-to-raster-image-file

--- a/Extensions/fonts/mcclim-fonts.asd
+++ b/Extensions/fonts/mcclim-fonts.asd
@@ -6,15 +6,11 @@
   :components ((:file "common")))
 
 (defsystem "mcclim-fonts/truetype"
-    :depends-on ("clim-basic" "zpb-ttf" "cl-vectors" "cl-paths-ttf" "cl-aa" "alexandria")
+    :depends-on ("clim-basic" "cl-dejavu" "zpb-ttf" "cl-vectors" "cl-paths-ttf" "cl-aa" "alexandria")
     :components ((:static-file "README.md")
                  (:file "truetype-package")
                  (:file "fontconfig" :depends-on ("truetype-package"))
                  (:file "mcclim-native-ttf" :depends-on ("truetype-package"))))
-
-(defmethod perform :after ((o load-op)
-                           (s (eql (find-system :mcclim-fonts/truetype))))
-  (uiop:symbol-call :mcclim-truetype :autoconfigure-fonts))
 
 (defsystem "mcclim-fonts/clx-freetype"
   :depends-on ("mcclim-fonts" "mcclim-clx" "cl-freetype2" "mcclim-fontconfig" "mcclim-harfbuzz")

--- a/Extensions/fonts/truetype-package.lisp
+++ b/Extensions/fonts/truetype-package.lisp
@@ -5,8 +5,6 @@
                 :when-let
                 :if-let)
   (:export #:*truetype-font-path*
-           #:*family-names*
-           #:*fontconfig-faces*
            #:*families/faces*
            #:*zpb-font-lock*
            #:truetype-device-font-name

--- a/Extensions/render/backend/port.lisp
+++ b/Extensions/render/backend/port.lisp
@@ -48,25 +48,11 @@
   (declare (ignore character-set))
   (labels
       ((find-and-make-truetype-font (family face size)
-         (let* ((font-path-maybe-relative
-                 (cdr (assoc (list family face) *families/faces*
-                             :test #'equal)))
-                (font-path
-                 (and font-path-maybe-relative
-                      (case (car (pathname-directory
-                                  font-path-maybe-relative))
-                        (:absolute font-path-maybe-relative)
-                        (otherwise (merge-pathnames
-                                    font-path-maybe-relative
-                                    (or *truetype-font-path* "")))))))
+         (let ((font-path
+                 (cdr (assoc (list family face) *families/faces* :test #'equal))))
            (if (and font-path (probe-file font-path))
                (make-truetype-font port font-path size)
-               ;; We could error here, but we want to fallback to
-               ;; fonts provided by CLX server. Its better to have
-               ;; ugly fonts than none at all.
-               (error 'missing-font
-                      :filename font-path
-                      :text-style text-style))))
+               (error 'missing-font :filename font-path :text-style text-style))))
        (find-font ()
          (multiple-value-call #'find-and-make-truetype-font
            (clim:text-style-components text-style))))


### PR DESCRIPTION
This saves us from a frequent issue that the system fonts can't be
found. cl-dejavu is available in quicklisp and contains prepackaged
dejavu fonts.

Changes:
- the variable *families/faces* always contains absolute pathnames
- fonts are autoconfigured in eval-when (not in asd file)
- ad-hoc fc-match implementation is removed as unnecessary

The variable *truetype-font-path* is preserved because it is used to
list the "system" fonts (and i.e to customize this path to load the
"user" fonts).